### PR TITLE
Add multi-row selection with bulk actions to PlaylistListViewV2

### DIFF
--- a/po/io.github.subsoundorg.Subsound.pot
+++ b/po/io.github.subsoundorg.Subsound.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Subsound\n"
 "Report-Msgid-Bugs-To: https://github.com/subsoundorg/subsound-gtk/issues\n"
-"POT-Creation-Date: 2026-07-22 00:37+0200\n"
+"POT-Creation-Date: 2026-07-29 18:16+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -38,7 +38,7 @@ msgstr ""
 #: src/main/java/org/subsound/MainApplication.java:310
 #: src/main/java/org/subsound/ui/components/CommandPalette.java:297
 #: src/main/java/org/subsound/ui/components/CommandPalette.java:328
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:457
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:468
 #, java-printf-format
 msgid "Album"
 msgstr ""
@@ -69,81 +69,81 @@ msgstr ""
 msgid "Artists"
 msgstr ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:721
+#: src/main/java/org/subsound/app/state/AppManager.java:733
 #, java-printf-format
 msgid "Failed to load song"
 msgstr ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:762
+#: src/main/java/org/subsound/app/state/AppManager.java:774
 #, java-printf-format
 msgid "Song not available offline"
 msgstr ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:978
+#: src/main/java/org/subsound/app/state/AppManager.java:991
 #, java-printf-format
 msgid "Playlist will be available offline"
 msgstr ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:981
+#: src/main/java/org/subsound/app/state/AppManager.java:995
 #, java-printf-format
 msgid "Offline sync off; downloads kept"
 msgstr ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:988
+#: src/main/java/org/subsound/app/state/AppManager.java:1003
 #, java-printf-format
 msgid "Added to %s"
 msgstr ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:996
+#: src/main/java/org/subsound/app/state/AppManager.java:1011
 #, java-printf-format
 msgid "Adding %1$d item to %2$s"
 msgid_plural "Adding %1$d items to %2$s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1013
+#: src/main/java/org/subsound/app/state/AppManager.java:1043
 #, java-printf-format
 msgid "Added to download queue"
 msgstr ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1022
+#: src/main/java/org/subsound/app/state/AppManager.java:1052
 #, java-printf-format
 msgid "Created playlist %s"
 msgstr ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1038
+#: src/main/java/org/subsound/app/state/AppManager.java:1068
 #, java-printf-format
 msgid "Added %d item to download queue"
 msgid_plural "Added %d items to download queue"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1050
+#: src/main/java/org/subsound/app/state/AppManager.java:1080
 #, java-printf-format
 msgid "Synced %1$d artists, %2$d albums, %3$d songs"
 msgstr ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1058
+#: src/main/java/org/subsound/app/state/AppManager.java:1088
 #, java-printf-format
 msgid "Song cache cleared"
 msgstr ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1062
+#: src/main/java/org/subsound/app/state/AppManager.java:1092
 #, java-printf-format
 msgid "Thumbnail cache cleared"
 msgstr ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1066
+#: src/main/java/org/subsound/app/state/AppManager.java:1096
 #, java-printf-format
 msgid "Lyrics cache cleared"
 msgstr ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1071
+#: src/main/java/org/subsound/app/state/AppManager.java:1101
 #, java-printf-format
 msgid "Started server scan"
 msgstr ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1076
+#: src/main/java/org/subsound/app/state/AppManager.java:1106
 #, java-printf-format
 msgid "Failed to start server: %s"
 msgstr ""
@@ -277,7 +277,7 @@ msgid "New playlist"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/components/PlaylistsListView.java:515
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1215
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1468
 #, java-printf-format
 msgid "Playlist name"
 msgstr ""
@@ -295,8 +295,8 @@ msgstr ""
 #. TRANSLATORS: "_" marks the mnemonic key
 #: src/main/java/org/subsound/ui/components/PlaylistsListView.java:524
 #: src/main/java/org/subsound/ui/components/ServerBadge.java:168
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1225
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1269
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1478
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1522
 #, java-printf-format
 msgid "_Cancel"
 msgstr ""
@@ -308,7 +308,7 @@ msgstr ""
 
 #: src/main/java/org/subsound/ui/components/PlaylistsListView.java:648
 #: src/main/java/org/subsound/ui/components/SongDownloadStatusIcon.java:44
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1121
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1370
 #, java-printf-format
 msgid "Available offline"
 msgstr ""
@@ -646,21 +646,22 @@ msgstr ""
 
 #: src/main/java/org/subsound/ui/components/SongContextMenu.java:68
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:417
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1351
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:718
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1604
 #, java-printf-format
 msgid "Play"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/components/SongContextMenu.java:74
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:438
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1374
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1627
 #, java-printf-format
 msgid "Play Next"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/components/SongContextMenu.java:80
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:444
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1380
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1633
 #, java-printf-format
 msgid "Add to Queue"
 msgstr ""
@@ -673,14 +674,16 @@ msgstr ""
 #: src/main/java/org/subsound/ui/components/SongContextMenu.java:101
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:459
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:673
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1386
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:722
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1639
 #, java-printf-format
 msgid "Add to Playlist…"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/components/SongContextMenu.java:112
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:464
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1389
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:729
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1642
 #, java-printf-format
 msgid "Download"
 msgstr ""
@@ -717,12 +720,13 @@ msgid "Add to Starred"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:450
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:733
 #, java-printf-format
 msgid "Unstar"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:490
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1430
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1683
 #, java-printf-format
 msgid "← Back"
 msgstr ""
@@ -735,7 +739,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:658
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1088
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1334
 #, java-printf-format
 msgid "Download all"
 msgstr ""
@@ -809,75 +813,100 @@ msgstr[1] ""
 msgid "Scanned %s ago"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:250
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:264
 #, java-printf-format
 msgid "Filter by title, artist, or album"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:379
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:698
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:390
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:942
 #, java-printf-format
 msgid "Title"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:488
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:499
 #, java-printf-format
 msgid "Duration"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:670
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:681
 #, java-printf-format
 msgid "Refresh playlist"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1087
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:704
 #, java-printf-format
-msgid "Rename…"
+msgid "Clear selection"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1089
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:720
 #, java-printf-format
-msgid "Delete Playlist…"
+msgid "Add to queue"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1221
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:731
 #, java-printf-format
-msgid "Rename Playlist"
+msgid "Star"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1222
-#, java-printf-format
-msgid "Enter a new name for \"%s\""
-msgstr ""
-
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1226
-#, java-printf-format
-msgid "_Rename"
-msgstr ""
-
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1265
-#, java-printf-format
-msgid "Delete Playlist"
-msgstr ""
-
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1266
-#, java-printf-format
-msgid "Delete \"%s\"? This cannot be undone."
-msgstr ""
-
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1270
-#, java-printf-format
-msgid "_Delete"
-msgstr ""
-
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1402
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:735
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:803
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1655
 #, java-printf-format
 msgid "Remove from Playlist"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1411
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:796
+#, java-printf-format
+msgid "%d selected"
+msgid_plural "%d selected"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:802
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1664
 #, java-printf-format
 msgid "Remove from Downloads"
+msgstr ""
+
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1333
+#, java-printf-format
+msgid "Rename…"
+msgstr ""
+
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1335
+#, java-printf-format
+msgid "Delete Playlist…"
+msgstr ""
+
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1474
+#, java-printf-format
+msgid "Rename Playlist"
+msgstr ""
+
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1475
+#, java-printf-format
+msgid "Enter a new name for \"%s\""
+msgstr ""
+
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1479
+#, java-printf-format
+msgid "_Rename"
+msgstr ""
+
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1518
+#, java-printf-format
+msgid "Delete Playlist"
+msgstr ""
+
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1519
+#, java-printf-format
+msgid "Delete \"%s\"? This cannot be undone."
+msgstr ""
+
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1523
+#, java-printf-format
+msgid "_Delete"
 msgstr ""
 
 #: src/main/java/org/subsound/utils/Utils.java:182

--- a/po/nb.po
+++ b/po/nb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Subsound\n"
 "Report-Msgid-Bugs-To: https://github.com/subsoundorg/subsound-gtk/issues\n"
-"POT-Creation-Date: 2026-07-22 00:37+0200\n"
+"POT-Creation-Date: 2026-07-29 18:16+0200\n"
 "PO-Revision-Date: 2026-07-11 00:16+0200\n"
 "Last-Translator: Eivind Siqveland Larsen <to.eivind@gmail.com>\n"
 "Language-Team: none\n"
@@ -37,7 +37,7 @@ msgstr "Søk"
 #: src/main/java/org/subsound/MainApplication.java:310
 #: src/main/java/org/subsound/ui/components/CommandPalette.java:297
 #: src/main/java/org/subsound/ui/components/CommandPalette.java:328
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:457
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:468
 #, java-printf-format
 msgid "Album"
 msgstr "Album"
@@ -68,81 +68,81 @@ msgstr "Spillelister"
 msgid "Artists"
 msgstr "Artister"
 
-#: src/main/java/org/subsound/app/state/AppManager.java:721
+#: src/main/java/org/subsound/app/state/AppManager.java:733
 #, java-printf-format
 msgid "Failed to load song"
 msgstr "Kunne ikke laste sangen"
 
-#: src/main/java/org/subsound/app/state/AppManager.java:762
+#: src/main/java/org/subsound/app/state/AppManager.java:774
 #, java-printf-format
 msgid "Song not available offline"
 msgstr "Sangen er ikke tilgjengelig frakoblet"
 
-#: src/main/java/org/subsound/app/state/AppManager.java:978
+#: src/main/java/org/subsound/app/state/AppManager.java:991
 #, fuzzy, java-printf-format
 msgid "Playlist will be available offline"
 msgstr "Spillelisten blir tilgjengelig frakoblet"
 
-#: src/main/java/org/subsound/app/state/AppManager.java:981
+#: src/main/java/org/subsound/app/state/AppManager.java:995
 #, java-printf-format
 msgid "Offline sync off; downloads kept"
 msgstr ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:988
+#: src/main/java/org/subsound/app/state/AppManager.java:1003
 #, java-printf-format
 msgid "Added to %s"
 msgstr "Lagt til i %s"
 
-#: src/main/java/org/subsound/app/state/AppManager.java:996
+#: src/main/java/org/subsound/app/state/AppManager.java:1011
 #, java-printf-format
 msgid "Adding %1$d item to %2$s"
 msgid_plural "Adding %1$d items to %2$s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1013
+#: src/main/java/org/subsound/app/state/AppManager.java:1043
 #, java-printf-format
 msgid "Added to download queue"
 msgstr "Lagt til i nedlastingskøen"
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1022
+#: src/main/java/org/subsound/app/state/AppManager.java:1052
 #, java-printf-format
 msgid "Created playlist %s"
 msgstr "Opprettet spillelisten %s"
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1038
+#: src/main/java/org/subsound/app/state/AppManager.java:1068
 #, java-printf-format
 msgid "Added %d item to download queue"
 msgid_plural "Added %d items to download queue"
 msgstr[0] "La til %d element i nedlastingskøen"
 msgstr[1] "La til %d elementer i nedlastingskøen"
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1050
+#: src/main/java/org/subsound/app/state/AppManager.java:1080
 #, java-printf-format
 msgid "Synced %1$d artists, %2$d albums, %3$d songs"
 msgstr "Synkroniserte %1$d artister, %2$d album, %3$d sanger"
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1058
+#: src/main/java/org/subsound/app/state/AppManager.java:1088
 #, java-printf-format
 msgid "Song cache cleared"
 msgstr "Lagrede sanger er slettet"
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1062
+#: src/main/java/org/subsound/app/state/AppManager.java:1092
 #, java-printf-format
 msgid "Thumbnail cache cleared"
 msgstr "Hurtiglager er tømt"
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1066
+#: src/main/java/org/subsound/app/state/AppManager.java:1096
 #, fuzzy, java-printf-format
 msgid "Lyrics cache cleared"
 msgstr "Lagrede sanger er slettet"
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1071
+#: src/main/java/org/subsound/app/state/AppManager.java:1101
 #, java-printf-format
 msgid "Started server scan"
 msgstr "Startet serverskanning"
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1076
+#: src/main/java/org/subsound/app/state/AppManager.java:1106
 #, java-printf-format
 msgid "Failed to start server: %s"
 msgstr ""
@@ -276,7 +276,7 @@ msgid "New playlist"
 msgstr "Ny spilleliste"
 
 #: src/main/java/org/subsound/ui/components/PlaylistsListView.java:515
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1215
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1468
 #, java-printf-format
 msgid "Playlist name"
 msgstr "Spillelistenavn"
@@ -294,8 +294,8 @@ msgstr "Skriv inn et navn på den nye spillelisten"
 #. TRANSLATORS: "_" marks the mnemonic key
 #: src/main/java/org/subsound/ui/components/PlaylistsListView.java:524
 #: src/main/java/org/subsound/ui/components/ServerBadge.java:168
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1225
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1269
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1478
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1522
 #, java-printf-format
 msgid "_Cancel"
 msgstr "_Avbryt"
@@ -307,7 +307,7 @@ msgstr "_Opprett"
 
 #: src/main/java/org/subsound/ui/components/PlaylistsListView.java:648
 #: src/main/java/org/subsound/ui/components/SongDownloadStatusIcon.java:44
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1121
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1370
 #, java-printf-format
 msgid "Available offline"
 msgstr ""
@@ -645,21 +645,22 @@ msgstr "Ja"
 
 #: src/main/java/org/subsound/ui/components/SongContextMenu.java:68
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:417
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1351
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:718
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1604
 #, java-printf-format
 msgid "Play"
 msgstr "Spill av"
 
 #: src/main/java/org/subsound/ui/components/SongContextMenu.java:74
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:438
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1374
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1627
 #, java-printf-format
 msgid "Play Next"
 msgstr "Spill neste"
 
 #: src/main/java/org/subsound/ui/components/SongContextMenu.java:80
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:444
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1380
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1633
 #, java-printf-format
 msgid "Add to Queue"
 msgstr "Legg til i kø"
@@ -672,14 +673,16 @@ msgstr "Legg til i favoritter"
 #: src/main/java/org/subsound/ui/components/SongContextMenu.java:101
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:459
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:673
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1386
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:722
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1639
 #, java-printf-format
 msgid "Add to Playlist…"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/components/SongContextMenu.java:112
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:464
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1389
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:729
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1642
 #, java-printf-format
 msgid "Download"
 msgstr "Last ned"
@@ -716,12 +719,13 @@ msgid "Add to Starred"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:450
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:733
 #, java-printf-format
 msgid "Unstar"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:490
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1430
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1683
 #, java-printf-format
 msgid "← Back"
 msgstr ""
@@ -734,7 +738,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:658
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1088
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1334
 #, java-printf-format
 msgid "Download all"
 msgstr "Last ned alle"
@@ -808,76 +812,101 @@ msgstr[1] ""
 msgid "Scanned %s ago"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:250
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:264
 #, java-printf-format
 msgid "Filter by title, artist, or album"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:379
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:698
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:390
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:942
 #, java-printf-format
 msgid "Title"
 msgstr "Tittel"
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:488
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:499
 #, java-printf-format
 msgid "Duration"
 msgstr "Lengde"
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:670
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:681
 #, java-printf-format
 msgid "Refresh playlist"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1087
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:704
 #, java-printf-format
-msgid "Rename…"
-msgstr "Gi nytt navn…"
-
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1089
-#, java-printf-format
-msgid "Delete Playlist…"
-msgstr "Slett spilleliste…"
-
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1221
-#, java-printf-format
-msgid "Rename Playlist"
-msgstr "Gi nytt navn"
-
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1222
-#, java-printf-format
-msgid "Enter a new name for \"%s\""
-msgstr "Skriv inn nytt navn for '%s'"
-
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1226
-#, java-printf-format
-msgid "_Rename"
-msgstr "_Gi nytt navn"
-
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1265
-#, java-printf-format
-msgid "Delete Playlist"
-msgstr "Slett spilleliste"
-
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1266
-#, java-printf-format
-msgid "Delete \"%s\"? This cannot be undone."
+msgid "Clear selection"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1270
-#, java-printf-format
-msgid "_Delete"
-msgstr "_Slett"
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:720
+#, fuzzy, java-printf-format
+msgid "Add to queue"
+msgstr "Legg til i kø"
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1402
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:731
+#, fuzzy, java-printf-format
+msgid "Star"
+msgstr "Favoritter"
+
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:735
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:803
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1655
 #, java-printf-format
 msgid "Remove from Playlist"
 msgstr "Fjern fra spilleliste"
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1411
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:796
+#, fuzzy, java-printf-format
+msgid "%d selected"
+msgid_plural "%d selected"
+msgstr[0] "%d sek"
+msgstr[1] "%d sek"
+
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:802
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1664
 #, java-printf-format
 msgid "Remove from Downloads"
 msgstr "Fjern fra nedlastinger"
+
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1333
+#, java-printf-format
+msgid "Rename…"
+msgstr "Gi nytt navn…"
+
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1335
+#, java-printf-format
+msgid "Delete Playlist…"
+msgstr "Slett spilleliste…"
+
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1474
+#, java-printf-format
+msgid "Rename Playlist"
+msgstr "Gi nytt navn"
+
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1475
+#, java-printf-format
+msgid "Enter a new name for \"%s\""
+msgstr "Skriv inn nytt navn for '%s'"
+
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1479
+#, java-printf-format
+msgid "_Rename"
+msgstr "_Gi nytt navn"
+
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1518
+#, java-printf-format
+msgid "Delete Playlist"
+msgstr "Slett spilleliste"
+
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1519
+#, java-printf-format
+msgid "Delete \"%s\"? This cannot be undone."
+msgstr ""
+
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1523
+#, java-printf-format
+msgid "_Delete"
+msgstr "_Slett"
 
 #: src/main/java/org/subsound/utils/Utils.java:182
 #: src/main/java/org/subsound/utils/Utils.java:206

--- a/src/main/java/org/subsound/app/state/AppManager.java
+++ b/src/main/java/org/subsound/app/state/AppManager.java
@@ -1023,6 +1023,21 @@ public class AppManager {
                     )));
                     //this.toast(new PlayerAction.Toast(new org.gnome.adw.Toast("Removed from " + a.playlistName())));
                 }
+                case PlayerAction.RemoveManyFromPlaylist a -> {
+                    if (PlaylistsStore.DOWNLOADED_ID.equals(a.playlistId())) {
+                        for (var song : a.songs()) {
+                            this.downloadManager.removeFromQueue(song.getId());
+                        }
+                        break;
+                    }
+                    // Send the whole selection as one atomic request so server-side positions
+                    // don't drift between individual removals.
+                    var removals = new ArrayList<ServerClient.SongRemoval>(a.songs().size());
+                    for (int i = 0; i < a.songs().size(); i++) {
+                        removals.add(new ServerClient.SongRemoval(a.originalPositions().get(i), a.songs().get(i).getId()));
+                    }
+                    this.useClient1(c -> c.playlistRemove(new PlaylistRemoveSongRequest(a.playlistId(), removals)));
+                }
                 case PlayerAction.AddToDownloadQueue a -> {
                     this.downloadManager.enqueue(a.song());
                     this.toast(new PlayerAction.Toast(new org.gnome.adw.Toast(tr("Added to download queue"))));

--- a/src/main/java/org/subsound/app/state/PlayerAction.java
+++ b/src/main/java/org/subsound/app/state/PlayerAction.java
@@ -48,6 +48,7 @@ public sealed interface PlayerAction {
     record Unstar(SongInfo song) implements PlayerAction {}
     record AddToPlaylist(SongInfo song, String playlistId, String playlistName) implements PlayerAction {}
     record RemoveFromPlaylist(SongInfo song, int originalPosition, String playlistId, String playlistName) implements PlayerAction {}
+    record RemoveManyFromPlaylist(List<GSongInfo> songs, List<Integer> originalPositions, String playlistId, String playlistName) implements PlayerAction {}
     record AddManyToPlaylist(List<GSongInfo> songs, String playlistId, String playlistName) implements PlayerAction {}
     record AddToDownloadQueue(SongInfo song) implements PlayerAction {}
     record AddManyToDownloadQueue(List<GSongInfo> songs) implements PlayerAction {}

--- a/src/main/java/org/subsound/ui/views/PlaylistListViewV2.java
+++ b/src/main/java/org/subsound/ui/views/PlaylistListViewV2.java
@@ -7,6 +7,7 @@ import org.gnome.gio.ListModel;
 import org.gnome.gio.ListStore;
 import org.gnome.glib.Type;
 import org.gnome.gobject.GObject;
+import org.gnome.gtk.ActionBar;
 import org.gnome.gtk.Box;
 import org.gnome.gtk.Button;
 import org.gnome.gtk.ColumnView;
@@ -30,8 +31,8 @@ import org.gnome.gtk.ScrolledWindow;
 import org.gnome.gtk.SearchBar;
 import org.gnome.gtk.SearchEntry;
 import org.gnome.gtk.Separator;
+import org.gnome.gtk.MultiSelection;
 import org.gnome.gtk.SignalListItemFactory;
-import org.gnome.gtk.SingleSelection;
 import org.gnome.gtk.SortListModel;
 import org.gnome.gtk.SortType;
 import org.gnome.gtk.Stack;
@@ -75,6 +76,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static com.twelvemonkeys.lang.StringUtil.containsIgnoreCase;
 import static org.gnome.adw.ResponseAppearance.DEFAULT;
@@ -87,6 +89,7 @@ import static org.gnome.gtk.Align.START;
 import static org.gnome.gtk.Orientation.HORIZONTAL;
 import static org.gnome.gtk.Orientation.VERTICAL;
 import static org.subsound.i18n.I18n.tr;
+import static org.subsound.i18n.I18n.trn;
 import static org.subsound.ui.components.AdwDialogHelper.CANCEL_LABEL_ID;
 import static org.subsound.ui.views.AlbumInfoPage.infoLabel;
 
@@ -111,9 +114,12 @@ public class PlaylistListViewV2 extends Box implements AppManager.StateListener 
     private volatile TitleArtistColumnSorter.States targetSort;
     private volatile String searchQuery = "";
     private final SortListModel<GPlaylistEntry> sortModel;
-    private final SingleSelection<GPlaylistEntry> selectionModel;
+    private final MultiSelection<GPlaylistEntry> selectionModel;
     private final SearchBar searchBar;
     private final SearchEntry searchEntry;
+    // Selection action bar shown above the list while 2+ rows are selected.
+    private final SelectionActionBar selectionBar;
+    @Nullable private SignalConnection<?> selectionChangedSignal = null;
     // Bound cells indexed by stable server songId. Each entry's qid lives on the cell's
     // boundEntry, so disambiguation between duplicate occurrences is a linear scan over
     // the per-songId list. Typical lists are size 1 (constant time); the pathological case
@@ -244,6 +250,13 @@ public class PlaylistListViewV2 extends Box implements AppManager.StateListener 
         // 3. Wire sorting over the filtered model: ColumnView aggregates per-column sorters.
         this.sortModel = new SortListModel<>(this.filterModel, this.columnView.getSorter());
 
+        // 4. Selection wraps sort model. MultiSelection enables ctrl/shift-click and Ctrl+A
+        // range selection natively (rubber-band drag-select is intentionally left disabled).
+        // Created before the search bar so the search handler can clear the selection.
+        this.selectionModel = new MultiSelection<>(this.sortModel);
+        this.columnView.setModel(this.selectionModel);
+        this.selectionChangedSignal = this.selectionModel.onSelectionChanged((position, nItems) -> updateSelectionBar());
+
         // Search bar — revealer that slides down above the list. Must be constructed
         // before the key controller since the Ctrl+F handler references these fields.
         this.searchEntry = SearchEntry.builder()
@@ -262,17 +275,14 @@ public class PlaylistListViewV2 extends Box implements AppManager.StateListener 
             var text = this.searchEntry.getText();
             this.searchQuery = text == null ? "" : text.trim();
             this.searchFilter.changed(FilterChange.DIFFERENT);
+            // Rows filtered out of view must not stay selected — acting on hidden rows is surprising.
+            this.selectionModel.unselectAll();
         });
         this.searchEntry.onStopSearch(() -> {
             // Escape pressed inside the entry — close and clear the filter.
             this.searchBar.setSearchMode(false);
             this.searchEntry.setText("");
         });
-
-        // 4. Selection wraps sort model
-        this.selectionModel = new SingleSelection<>(this.sortModel);
-        this.columnView.setModel(this.selectionModel);
-
 
         // 5. Build columns with per-column factories and sorters, then append them
 
@@ -579,16 +589,12 @@ public class PlaylistListViewV2 extends Box implements AppManager.StateListener 
             if (playlist == null) {
                 return false;
             }
-            var entry = selectionModel.getSelectedItem();
-            if (entry == null) {
+            var entries = selectedEntries();
+            if (entries.isEmpty()) {
                 return false;
             }
-            if (playlist.kind() == PlaylistKind.NORMAL) {
-                removeFromPlaylist(entry);
-                return true;
-            }
-            if (playlist.kind() == PlaylistKind.DOWNLOADED) {
-                removeFromDownloads(entry);
+            if (playlist.kind() == PlaylistKind.NORMAL || playlist.kind() == PlaylistKind.DOWNLOADED) {
+                removeEntries(entries, playlist);
                 return true;
             }
             return false;
@@ -625,6 +631,10 @@ public class PlaylistListViewV2 extends Box implements AppManager.StateListener 
             if (playlistNotifySignal != null) {
                 playlistNotifySignal.disconnect();
                 playlistNotifySignal = null;
+            }
+            if (selectionChangedSignal != null) {
+                selectionChangedSignal.disconnect();
+                selectionChangedSignal = null;
             }
             unbindSource();
             mapSignal.disconnect();
@@ -687,9 +697,212 @@ public class PlaylistListViewV2 extends Box implements AppManager.StateListener 
         headerBox.append(this.reloadButton);
         headerBox.append(this.menuButton);
 
+        // Selection action bar. The bar only reports which button was clicked; this view owns
+        // the action logic and controls the bar's visibility (see updateSelectionBar).
+        this.selectionBar = new SelectionActionBar(this::onBulkAction);
+
         this.append(headerBox);
         this.append(this.searchBar);
+        this.append(this.selectionBar);
         this.append(this.scroll);
+    }
+
+    /**
+     * Entries currently selected, in the view's sort order. Walks only the selected positions
+     * via the selection {@link org.gnome.gtk.Bitset} — O(selected), not O(list) — so a sparse
+     * selection in a large playlist (e.g. the first and last of 2000 songs) stays cheap.
+     * {@code getItem} reads from the backing model, so entries whose rows were recycled out of
+     * view are still returned. Must be called on the GTK main thread.
+     */
+    private List<GPlaylistEntry> selectedEntries() {
+        var selection = this.selectionModel.getSelection();
+        int count = (int) selection.getSize();
+        var out = new ArrayList<GPlaylistEntry>(count);
+        for (int i = 0; i < count; i++) {
+            // getNth(i) is the i-th smallest selected position, i.e. ascending view order.
+            var e = this.selectionModel.getItem(selection.getNth(i));
+            if (e != null) {
+                out.add(e);
+            }
+        }
+        return out;
+    }
+
+    private List<GSongInfo> selectedGSongs() {
+        var entries = selectedEntries();
+        var out = new ArrayList<GSongInfo>(entries.size());
+        for (var e : entries) {
+            out.add(e.gSong());
+        }
+        return out;
+    }
+
+    /**
+     * Visibility policy for the selection bar: only a multi-row selection (2+) surfaces it, so a
+     * single selected row stays the normal "pick a song to play" case. Main thread only.
+     */
+    private void updateSelectionBar() {
+        int count = (int) this.selectionModel.getSelection().getSize();
+        boolean show = count >= 2;
+        if (show) {
+            var playlist = this.currentPlaylist.get();
+            this.selectionBar.setContent(count, playlist == null ? null : playlist.kind());
+        }
+        this.selectionBar.setRevealed(show);
+    }
+
+    /** Dispatch a bar button click to the matching bulk action. Main thread only. */
+    private void onBulkAction(SelectionActionBar.BulkAction action) {
+        switch (action) {
+            case CLEAR -> this.selectionModel.unselectAll();
+            case PLAY -> bulkPlay();
+            case ADD_TO_QUEUE -> bulkAddToQueue();
+            case ADD_TO_PLAYLIST -> openBulkAddToPlaylist();
+            case DOWNLOAD -> bulkDownload();
+            case STAR -> bulkStar();
+            case UNSTAR -> bulkUnstar();
+            case REMOVE -> bulkRemove();
+        }
+    }
+
+    /** Pop up the playlist picker anchored to the selection bar, adding the selection on pick. */
+    private void openBulkAddToPlaylist() {
+        var popover = buildBulkAddToPlaylistPopover();
+        popover.setParent(this.selectionBar);
+        popover.onClosed(() -> popover.unparent());
+        popover.popup();
+    }
+
+    private void bulkPlay() {
+        var playlist = this.currentPlaylist.get();
+        if (playlist == null) {
+            return;
+        }
+        var entries = selectedEntries();
+        if (entries.isEmpty()) {
+            return;
+        }
+        var slots = new ArrayList<PlayerAction.QueueSlot>(entries.size());
+        for (var e : entries) {
+            slots.add(new PlayerAction.QueueSlot(e.getQueueItemId(), e.song()));
+        }
+        this.onAction.apply(new PlayerAction.PlayAndReplaceQueue(new PlaylistIdentifier(playlist.id()), slots, 0));
+    }
+
+    private void bulkAddToQueue() {
+        for (var e : selectedEntries()) {
+            this.onAction.apply(new PlayerAction.EnqueueLast(e.song()));
+        }
+    }
+
+    private void bulkDownload() {
+        var songs = selectedGSongs();
+        if (!songs.isEmpty()) {
+            this.onAction.apply(new PlayerAction.AddManyToDownloadQueue(songs));
+        }
+    }
+
+    private void bulkStar() {
+        for (var e : selectedEntries()) {
+            this.onAction.apply(new PlayerAction.Star2(e.gSong()));
+        }
+    }
+
+    private void bulkUnstar() {
+        for (var e : selectedEntries()) {
+            this.onAction.apply(new PlayerAction.Unstar(e.song()));
+        }
+    }
+
+    private void bulkRemove() {
+        var playlist = this.currentPlaylist.get();
+        if (playlist == null) {
+            return;
+        }
+        if (playlist.kind() != PlaylistKind.NORMAL && playlist.kind() != PlaylistKind.DOWNLOADED) {
+            return;
+        }
+        var entries = selectedEntries();
+        if (!entries.isEmpty()) {
+            removeEntries(entries, playlist);
+        }
+    }
+
+    /**
+     * Remove a set of entries from the current playlist (normal or downloaded) in one atomic
+     * request, then reconcile the local model: drop the removed rows and renumber the tail's
+     * position/queueItemId so highlighting keeps matching. Main thread only.
+     */
+    private void removeEntries(List<GPlaylistEntry> entries, ServerClient.PlaylistSimple playlist) {
+        var songs = new ArrayList<GSongInfo>(entries.size());
+        var positions = new ArrayList<Integer>(entries.size());
+        for (var e : entries) {
+            songs.add(e.gSong());
+            positions.add(e.position());
+        }
+        this.onAction.apply(new PlayerAction.RemoveManyFromPlaylist(songs, positions, playlist.id(), playlist.name()));
+
+        var toRemove = new java.util.HashSet<>(entries);
+        var playlistId = playlist.id();
+        for (int i = this.listModel.getNItems() - 1; i >= 0; i--) {
+            var e = this.listModel.getItem(i);
+            if (e != null && toRemove.contains(e)) {
+                this.listModel.remove(i);
+            }
+        }
+        for (int i = 0; i < this.listModel.getNItems(); i++) {
+            var e = this.listModel.getItem(i);
+            if (e != null) {
+                e.setPosition(i);
+                e.setQueueItemId(GPlaylistEntry.makeQueueItemId(playlistId, e.song().id(), i));
+            }
+        }
+        this.selectionModel.unselectAll();
+    }
+
+    /** Append a menu-item button per NORMAL playlist, invoking {@code onPick} on click. */
+    private void appendPlaylistTargets(Box container, Consumer<GPlaylist> onPick) {
+        var playlists = appManager.getPlaylistsListStore();
+        for (int i = 0; i < playlists.getNItems(); i++) {
+            GPlaylist gPlaylist = playlists.getItem(i);
+            if (gPlaylist.getPlaylist().kind() != PlaylistKind.NORMAL) {
+                continue;
+            }
+            var gp = gPlaylist;
+            var btn = menuItem(gp.getName());
+            btn.onClicked(() -> onPick.accept(gp));
+            container.append(btn);
+        }
+    }
+
+    private Popover buildBulkAddToPlaylistPopover() {
+        var box = Box.builder()
+                .setOrientation(VERTICAL)
+                .setSpacing(2)
+                .setMarginTop(4)
+                .setMarginBottom(4)
+                .setMarginStart(4)
+                .setMarginEnd(4)
+                .build();
+        var popover = new Popover();
+        var scrollList = ScrolledWindow.builder()
+                .setPropagateNaturalWidth(true)
+                .setPropagateNaturalHeight(true)
+                .setMaxContentHeight(300)
+                .build();
+        scrollList.setChild(box);
+        var clamp = new Clamp();
+        clamp.setMaximumSize(220);
+        clamp.setChild(scrollList);
+        popover.setChild(clamp);
+        appendPlaylistTargets(box, gp -> {
+            popover.popdown();
+            var songs = selectedGSongs();
+            if (!songs.isEmpty()) {
+                this.onAction.apply(new PlayerAction.AddManyToPlaylist(songs, gp.getId(), gp.getName()));
+            }
+        });
+        return popover;
     }
 
     private void resetColumnSorting() {
@@ -802,6 +1015,8 @@ public class PlaylistListViewV2 extends Box implements AppManager.StateListener 
                 if (oldN > 0 && n > 0) {
                     this.columnView.scrollTo(0, this.titleCol, ListScrollFlags.NONE, null);
                 }
+                // Replacing the list invalidates any prior selection; drop it (and hide the bar).
+                this.selectionModel.unselectAll();
                 this.listModel.splice(0, oldN, new GPlaylistEntry[0]);
                 this.resetColumnSorting();
                 long tAfterClear = System.nanoTime();
@@ -1080,6 +1295,90 @@ public class PlaylistListViewV2 extends Box implements AppManager.StateListener 
             case PLAYING -> NowPlayingState.PLAYING;
             case END_OF_STREAM -> NowPlayingState.NONE;
         };
+    }
+
+    // ---- Selection action bar ----
+
+    /**
+     * Bulk-action bar shown above the list while multiple rows are selected. Purely
+     * presentational: it emits which button was pressed via {@link BulkAction} and exposes only
+     * {@link #setContent} for the count/kind-dependent labels. It knows nothing about the
+     * selection or list models, and the parent view decides when it is revealed. Mirrors
+     * {@link PlaylistMenu}'s callback-in-constructor style.
+     */
+    private static class SelectionActionBar extends ActionBar {
+        enum BulkAction { CLEAR, PLAY, ADD_TO_QUEUE, ADD_TO_PLAYLIST, DOWNLOAD, STAR, UNSTAR, REMOVE }
+
+        private final Label countLabel;
+        private final Button removeButton;
+
+        SelectionActionBar(Consumer<BulkAction> onAction) {
+            super();
+
+            var clearButton = Button.builder()
+                    .setIconName("window-close-symbolic")
+                    .setTooltipText(tr("Clear selection"))
+                    .build();
+            clearButton.addCssClass("flat");
+            clearButton.addCssClass("circular");
+            clearButton.onClicked(() -> onAction.accept(BulkAction.CLEAR));
+
+            this.countLabel = new Label("");
+            this.countLabel.addCssClass(Classes.labelDim.className());
+            this.countLabel.setValign(CENTER);
+
+            var start = new Box(HORIZONTAL, 8);
+            start.append(clearButton);
+            start.append(this.countLabel);
+
+            var playButton = barButton(tr("Play"));
+            playButton.onClicked(() -> onAction.accept(BulkAction.PLAY));
+            var queueButton = barButton(tr("Add to queue"));
+            queueButton.onClicked(() -> onAction.accept(BulkAction.ADD_TO_QUEUE));
+            var addPlaylistButton = barButton(tr("Add to Playlist…"));
+            addPlaylistButton.onClicked(() -> onAction.accept(BulkAction.ADD_TO_PLAYLIST));
+            var downloadButton = barButton(tr("Download"));
+            downloadButton.onClicked(() -> onAction.accept(BulkAction.DOWNLOAD));
+            var starButton = barButton(tr("Star"));
+            starButton.onClicked(() -> onAction.accept(BulkAction.STAR));
+            var unstarButton = barButton(tr("Unstar"));
+            unstarButton.onClicked(() -> onAction.accept(BulkAction.UNSTAR));
+            this.removeButton = barButton(tr("Remove from Playlist"));
+            this.removeButton.addCssClass("destructive-action");
+            this.removeButton.onClicked(() -> onAction.accept(BulkAction.REMOVE));
+
+            var end = new Box(HORIZONTAL, 6);
+            end.append(playButton);
+            end.append(queueButton);
+            end.append(addPlaylistButton);
+            end.append(downloadButton);
+            end.append(starButton);
+            end.append(unstarButton);
+            end.append(this.removeButton);
+
+            this.packStart(start);
+            this.packEnd(end);
+            this.setRevealed(false);
+        }
+
+        /**
+         * Update the count label and tailor the Remove button to the playlist kind. Presentation
+         * only — the parent decides whether the bar is revealed via {@link #setRevealed}.
+         */
+        void setContent(int count, @Nullable PlaylistKind kind) {
+            this.countLabel.setLabel(trn("%d selected", "%d selected", count).formatted(count));
+            boolean canRemove = kind == PlaylistKind.NORMAL || kind == PlaylistKind.DOWNLOADED;
+            this.removeButton.setVisible(canRemove);
+            this.removeButton.setLabel(kind == PlaylistKind.DOWNLOADED
+                    ? tr("Remove from Downloads")
+                    : tr("Remove from Playlist"));
+        }
+
+        private static Button barButton(String label) {
+            var button = Button.builder().setLabel(label).setValign(CENTER).build();
+            button.addCssClass("flat");
+            return button;
+        }
     }
 
     // ---- Playlist menu ----
@@ -1439,21 +1738,10 @@ public class PlaylistListViewV2 extends Box implements AppManager.StateListener 
         playlistsView.append(backButton);
         playlistsView.append(new Separator(HORIZONTAL));
 
-        var playlists = appManager.getPlaylistsListStore();
-        for (int i = 0; i < playlists.getNItems(); i++) {
-            GPlaylist gPlaylist = playlists.getItem(i);
-            if (gPlaylist.getPlaylist().kind() != PlaylistKind.NORMAL) {
-                continue;
-            }
-            String pid = gPlaylist.getId();
-            String pname = gPlaylist.getName();
-            var btn = menuItem(pname);
-            btn.onClicked(() -> {
-                menuPopover.popdown();
-                onAction.apply(new PlayerAction.AddToPlaylist(entry.song(), pid, pname));
-            });
-            playlistsView.append(btn);
-        }
+        appendPlaylistTargets(playlistsView, gp -> {
+            menuPopover.popdown();
+            onAction.apply(new PlayerAction.AddToPlaylist(entry.song(), gp.getId(), gp.getName()));
+        });
 
         var playlistsScroll = ScrolledWindow.builder()
                 .setPropagateNaturalWidth(true)
@@ -1780,7 +2068,6 @@ public class PlaylistListViewV2 extends Box implements AppManager.StateListener 
                 if (entry == null) {
                     return;
                 }
-                selectionModel.setSelected(item.getPosition());
                 var popover = buildRowContextMenu(entry);
                 popover.setParent(this.menuButton);
                 popover.onClosed(() -> popover.unparent());


### PR DESCRIPTION
Swap the ColumnView's SingleSelection for MultiSelection so rows can be selected with ctrl/shift-click and Ctrl+A (rubber-band drag-select left off). A selection ActionBar is revealed above the list only when 2+ rows are selected, keeping the normal single-row "pick a song to play" flow untouched. The bar offers Play, Add to queue, Add to Playlist, Download, Star, Unstar and Remove over the whole selection.

Selected entries are gathered by walking the selection Bitset via getNth (O(selected), not O(list)), so a sparse selection in a large playlist stays cheap and rows recycled out of view still resolve from the model.

Bulk remove goes through a new atomic RemoveManyFromPlaylist action: one playlistRemove request with the original positions (no index drift), or a per-song download-queue removal for the Downloaded list. The Delete key now removes the whole selection.
