### PR TITLE
Add ReplayGain loudness normalization support

### DIFF
--- a/po/io.github.subsoundorg.Subsound.pot
+++ b/po/io.github.subsoundorg.Subsound.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Subsound\n"
 "Report-Msgid-Bugs-To: https://github.com/subsoundorg/subsound-gtk/issues\n"
-"POT-Creation-Date: 2026-07-29 18:16+0200\n"
+"POT-Creation-Date: 2026-07-31 17:54+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -38,7 +38,8 @@ msgstr ""
 #: src/main/java/org/subsound/MainApplication.java:310
 #: src/main/java/org/subsound/ui/components/CommandPalette.java:297
 #: src/main/java/org/subsound/ui/components/CommandPalette.java:328
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:468
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:191
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:467
 #, java-printf-format
 msgid "Album"
 msgstr ""
@@ -69,81 +70,81 @@ msgstr ""
 msgid "Artists"
 msgstr ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:733
+#: src/main/java/org/subsound/app/state/AppManager.java:740
 #, java-printf-format
 msgid "Failed to load song"
 msgstr ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:774
+#: src/main/java/org/subsound/app/state/AppManager.java:781
 #, java-printf-format
 msgid "Song not available offline"
 msgstr ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:991
+#: src/main/java/org/subsound/app/state/AppManager.java:1003
 #, java-printf-format
 msgid "Playlist will be available offline"
 msgstr ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:995
+#: src/main/java/org/subsound/app/state/AppManager.java:1007
 #, java-printf-format
 msgid "Offline sync off; downloads kept"
 msgstr ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1003
+#: src/main/java/org/subsound/app/state/AppManager.java:1015
 #, java-printf-format
 msgid "Added to %s"
 msgstr ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1011
+#: src/main/java/org/subsound/app/state/AppManager.java:1023
 #, java-printf-format
 msgid "Adding %1$d item to %2$s"
 msgid_plural "Adding %1$d items to %2$s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1043
+#: src/main/java/org/subsound/app/state/AppManager.java:1055
 #, java-printf-format
 msgid "Added to download queue"
 msgstr ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1052
+#: src/main/java/org/subsound/app/state/AppManager.java:1064
 #, java-printf-format
 msgid "Created playlist %s"
 msgstr ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1068
+#: src/main/java/org/subsound/app/state/AppManager.java:1080
 #, java-printf-format
 msgid "Added %d item to download queue"
 msgid_plural "Added %d items to download queue"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1080
+#: src/main/java/org/subsound/app/state/AppManager.java:1092
 #, java-printf-format
 msgid "Synced %1$d artists, %2$d albums, %3$d songs"
 msgstr ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1088
+#: src/main/java/org/subsound/app/state/AppManager.java:1100
 #, java-printf-format
 msgid "Song cache cleared"
 msgstr ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1092
+#: src/main/java/org/subsound/app/state/AppManager.java:1104
 #, java-printf-format
 msgid "Thumbnail cache cleared"
 msgstr ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1096
+#: src/main/java/org/subsound/app/state/AppManager.java:1108
 #, java-printf-format
 msgid "Lyrics cache cleared"
 msgstr ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1101
+#: src/main/java/org/subsound/app/state/AppManager.java:1113
 #, java-printf-format
 msgid "Started server scan"
 msgstr ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1106
+#: src/main/java/org/subsound/app/state/AppManager.java:1118
 #, java-printf-format
 msgid "Failed to start server: %s"
 msgstr ""
@@ -266,7 +267,7 @@ msgid "Select a playlist to view"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/components/PlaylistsListView.java:271
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:198
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:252
 #, java-printf-format
 msgid "Library"
 msgstr ""
@@ -277,7 +278,7 @@ msgid "New playlist"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/components/PlaylistsListView.java:515
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1468
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1521
 #, java-printf-format
 msgid "Playlist name"
 msgstr ""
@@ -295,8 +296,8 @@ msgstr ""
 #. TRANSLATORS: "_" marks the mnemonic key
 #: src/main/java/org/subsound/ui/components/PlaylistsListView.java:524
 #: src/main/java/org/subsound/ui/components/ServerBadge.java:168
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1478
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1522
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1531
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1575
 #, java-printf-format
 msgid "_Cancel"
 msgstr ""
@@ -306,17 +307,10 @@ msgstr ""
 msgid "_Create"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:648
-#: src/main/java/org/subsound/ui/components/SongDownloadStatusIcon.java:44
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1370
-#, java-printf-format
-msgid "Available offline"
-msgstr ""
-
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:693
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:697
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:700
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:705
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:684
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:688
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:691
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:696
 #, java-printf-format
 msgid "%d item"
 msgid_plural "%d items"
@@ -502,166 +496,211 @@ msgstr ""
 msgid "Configuration saved!"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:76
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:84
 #, java-printf-format
 msgid "Clear song cache"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:80
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:88
 #, java-printf-format
 msgid "Clear thumbnail cache"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:84
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:92
 #, java-printf-format
 msgid "Clear lyrics cache"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:89
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:97
 #, java-printf-format
 msgid "Local Settings"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:99
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:123
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:107
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:131
 #, java-printf-format
 msgid "Source"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:116
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:124
 #, java-printf-format
 msgid "Audio format"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:127
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:135
 #, java-printf-format
 msgid "Max bitrate"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:153
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:161
 #, java-printf-format
 msgid "Server information"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:155
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:163
 #, java-printf-format
 msgid "Type"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:156
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:164
 #, java-printf-format
 msgid "Version"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:157
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:165
 #, java-printf-format
 msgid "API Version"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:158
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:166
 #, java-printf-format
 msgid "OpenSubsonic support"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:163
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:171
 #, java-printf-format
 msgid "OpenSubsonic extensions"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:168
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:176
 #, java-printf-format
 msgid "Transcode Settings"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:174
-#, java-printf-format
-msgid "Full scan"
-msgstr ""
-
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:176
-#, java-printf-format
-msgid "Start server scan for new songs and folders"
-msgstr ""
-
 #: src/main/java/org/subsound/ui/components/SettingsPage.java:184
 #, java-printf-format
-msgid "Quick scan"
+msgid "Enable ReplayGain"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:186
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:185
 #, java-printf-format
-msgid "Start server quick scan for new songs and folders"
+msgid "Normalize playback loudness across tracks"
+msgstr ""
+
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:190
+#, java-printf-format
+msgid "Track"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/components/SettingsPage.java:193
 #, java-printf-format
-msgid "Last Scanned at"
+msgid "Normalization mode"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/components/SettingsPage.java:194
 #, java-printf-format
-msgid "Status"
+msgid "Album mode preserves an album's internal dynamics"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:195
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:199
 #, java-printf-format
-msgid "Server songs"
+msgid "Pre-amp (dB)"
+msgstr ""
+
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:204
+#, java-printf-format
+msgid "Fallback gain (dB)"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/components/SettingsPage.java:205
 #, java-printf-format
+msgid "Applied to tracks without ReplayGain data"
+msgstr ""
+
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:210
+#, java-printf-format
+msgid "ReplayGain"
+msgstr ""
+
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:228
+#, java-printf-format
+msgid "Full scan"
+msgstr ""
+
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:230
+#, java-printf-format
+msgid "Start server scan for new songs and folders"
+msgstr ""
+
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:238
+#, java-printf-format
+msgid "Quick scan"
+msgstr ""
+
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:240
+#, java-printf-format
+msgid "Start server quick scan for new songs and folders"
+msgstr ""
+
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:247
+#, java-printf-format
+msgid "Last Scanned at"
+msgstr ""
+
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:248
+#, java-printf-format
+msgid "Status"
+msgstr ""
+
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:249
+#, java-printf-format
+msgid "Server songs"
+msgstr ""
+
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:259
+#, java-printf-format
 msgid "Local songs"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:209
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:263
 #, java-printf-format
 msgid "Sync library"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:211
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:265
 #, java-printf-format
 msgid "Syncs metadata for offline use"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:226
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:280
 #, java-printf-format
 msgid "Local Library"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:284
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:285
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:359
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:360
 #, java-printf-format
 msgid "Unknown"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:287
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:362
 #, java-printf-format
 msgid "No"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:287
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:362
 #, java-printf-format
 msgid "Yes"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/components/SongContextMenu.java:68
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:417
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:718
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1604
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1334
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1657
 #, java-printf-format
 msgid "Play"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/components/SongContextMenu.java:74
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:438
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1627
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1680
 #, java-printf-format
 msgid "Play Next"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/components/SongContextMenu.java:80
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:444
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1633
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1686
 #, java-printf-format
 msgid "Add to Queue"
 msgstr ""
@@ -674,18 +713,24 @@ msgstr ""
 #: src/main/java/org/subsound/ui/components/SongContextMenu.java:101
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:459
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:673
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:722
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1639
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1338
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1692
 #, java-printf-format
 msgid "Add to Playlist…"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/components/SongContextMenu.java:112
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:464
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:729
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1642
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1340
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1695
 #, java-printf-format
 msgid "Download"
+msgstr ""
+
+#: src/main/java/org/subsound/ui/components/SongDownloadStatusIcon.java:44
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1423
+#, java-printf-format
+msgid "Available offline"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/components/SongDownloadStatusIcon.java:50
@@ -720,13 +765,13 @@ msgid "Add to Starred"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:450
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:733
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1344
 #, java-printf-format
 msgid "Unstar"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:490
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1683
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1736
 #, java-printf-format
 msgid "← Back"
 msgstr ""
@@ -739,7 +784,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:658
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1334
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1387
 #, java-printf-format
 msgid "Download all"
 msgstr ""
@@ -813,98 +858,98 @@ msgstr[1] ""
 msgid "Scanned %s ago"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:264
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:263
 #, java-printf-format
 msgid "Filter by title, artist, or album"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:390
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:942
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:389
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:911
 #, java-printf-format
 msgid "Title"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:499
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:498
 #, java-printf-format
 msgid "Duration"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:681
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:680
 #, java-printf-format
 msgid "Refresh playlist"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:704
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1320
 #, java-printf-format
 msgid "Clear selection"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:720
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1336
 #, java-printf-format
 msgid "Add to queue"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:731
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1342
 #, java-printf-format
 msgid "Star"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:735
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:803
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1655
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1346
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1374
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1708
 #, java-printf-format
 msgid "Remove from Playlist"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:796
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1369
 #, java-printf-format
 msgid "%d selected"
 msgid_plural "%d selected"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:802
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1664
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1373
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1717
 #, java-printf-format
 msgid "Remove from Downloads"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1333
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1386
 #, java-printf-format
 msgid "Rename…"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1335
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1388
 #, java-printf-format
 msgid "Delete Playlist…"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1474
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1527
 #, java-printf-format
 msgid "Rename Playlist"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1475
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1528
 #, java-printf-format
 msgid "Enter a new name for \"%s\""
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1479
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1532
 #, java-printf-format
 msgid "_Rename"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1518
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1571
 #, java-printf-format
 msgid "Delete Playlist"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1519
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1572
 #, java-printf-format
 msgid "Delete \"%s\"? This cannot be undone."
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1523
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1576
 #, java-printf-format
 msgid "_Delete"
 msgstr ""

--- a/po/nb.po
+++ b/po/nb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Subsound\n"
 "Report-Msgid-Bugs-To: https://github.com/subsoundorg/subsound-gtk/issues\n"
-"POT-Creation-Date: 2026-07-29 18:16+0200\n"
+"POT-Creation-Date: 2026-07-31 17:54+0200\n"
 "PO-Revision-Date: 2026-07-11 00:16+0200\n"
 "Last-Translator: Eivind Siqveland Larsen <to.eivind@gmail.com>\n"
 "Language-Team: none\n"
@@ -37,7 +37,8 @@ msgstr "Søk"
 #: src/main/java/org/subsound/MainApplication.java:310
 #: src/main/java/org/subsound/ui/components/CommandPalette.java:297
 #: src/main/java/org/subsound/ui/components/CommandPalette.java:328
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:468
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:191
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:467
 #, java-printf-format
 msgid "Album"
 msgstr "Album"
@@ -68,81 +69,81 @@ msgstr "Spillelister"
 msgid "Artists"
 msgstr "Artister"
 
-#: src/main/java/org/subsound/app/state/AppManager.java:733
+#: src/main/java/org/subsound/app/state/AppManager.java:740
 #, java-printf-format
 msgid "Failed to load song"
 msgstr "Kunne ikke laste sangen"
 
-#: src/main/java/org/subsound/app/state/AppManager.java:774
+#: src/main/java/org/subsound/app/state/AppManager.java:781
 #, java-printf-format
 msgid "Song not available offline"
 msgstr "Sangen er ikke tilgjengelig frakoblet"
 
-#: src/main/java/org/subsound/app/state/AppManager.java:991
+#: src/main/java/org/subsound/app/state/AppManager.java:1003
 #, fuzzy, java-printf-format
 msgid "Playlist will be available offline"
 msgstr "Spillelisten blir tilgjengelig frakoblet"
 
-#: src/main/java/org/subsound/app/state/AppManager.java:995
+#: src/main/java/org/subsound/app/state/AppManager.java:1007
 #, java-printf-format
 msgid "Offline sync off; downloads kept"
 msgstr ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1003
+#: src/main/java/org/subsound/app/state/AppManager.java:1015
 #, java-printf-format
 msgid "Added to %s"
 msgstr "Lagt til i %s"
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1011
+#: src/main/java/org/subsound/app/state/AppManager.java:1023
 #, java-printf-format
 msgid "Adding %1$d item to %2$s"
 msgid_plural "Adding %1$d items to %2$s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1043
+#: src/main/java/org/subsound/app/state/AppManager.java:1055
 #, java-printf-format
 msgid "Added to download queue"
 msgstr "Lagt til i nedlastingskøen"
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1052
+#: src/main/java/org/subsound/app/state/AppManager.java:1064
 #, java-printf-format
 msgid "Created playlist %s"
 msgstr "Opprettet spillelisten %s"
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1068
+#: src/main/java/org/subsound/app/state/AppManager.java:1080
 #, java-printf-format
 msgid "Added %d item to download queue"
 msgid_plural "Added %d items to download queue"
 msgstr[0] "La til %d element i nedlastingskøen"
 msgstr[1] "La til %d elementer i nedlastingskøen"
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1080
+#: src/main/java/org/subsound/app/state/AppManager.java:1092
 #, java-printf-format
 msgid "Synced %1$d artists, %2$d albums, %3$d songs"
 msgstr "Synkroniserte %1$d artister, %2$d album, %3$d sanger"
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1088
+#: src/main/java/org/subsound/app/state/AppManager.java:1100
 #, java-printf-format
 msgid "Song cache cleared"
 msgstr "Lagrede sanger er slettet"
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1092
+#: src/main/java/org/subsound/app/state/AppManager.java:1104
 #, java-printf-format
 msgid "Thumbnail cache cleared"
 msgstr "Hurtiglager er tømt"
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1096
+#: src/main/java/org/subsound/app/state/AppManager.java:1108
 #, fuzzy, java-printf-format
 msgid "Lyrics cache cleared"
 msgstr "Lagrede sanger er slettet"
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1101
+#: src/main/java/org/subsound/app/state/AppManager.java:1113
 #, java-printf-format
 msgid "Started server scan"
 msgstr "Startet serverskanning"
 
-#: src/main/java/org/subsound/app/state/AppManager.java:1106
+#: src/main/java/org/subsound/app/state/AppManager.java:1118
 #, java-printf-format
 msgid "Failed to start server: %s"
 msgstr ""
@@ -265,7 +266,7 @@ msgid "Select a playlist to view"
 msgstr "Velg en spilleliste for å vise"
 
 #: src/main/java/org/subsound/ui/components/PlaylistsListView.java:271
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:198
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:252
 #, java-printf-format
 msgid "Library"
 msgstr "Bibliotek"
@@ -276,7 +277,7 @@ msgid "New playlist"
 msgstr "Ny spilleliste"
 
 #: src/main/java/org/subsound/ui/components/PlaylistsListView.java:515
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1468
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1521
 #, java-printf-format
 msgid "Playlist name"
 msgstr "Spillelistenavn"
@@ -294,8 +295,8 @@ msgstr "Skriv inn et navn på den nye spillelisten"
 #. TRANSLATORS: "_" marks the mnemonic key
 #: src/main/java/org/subsound/ui/components/PlaylistsListView.java:524
 #: src/main/java/org/subsound/ui/components/ServerBadge.java:168
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1478
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1522
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1531
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1575
 #, java-printf-format
 msgid "_Cancel"
 msgstr "_Avbryt"
@@ -305,17 +306,10 @@ msgstr "_Avbryt"
 msgid "_Create"
 msgstr "_Opprett"
 
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:648
-#: src/main/java/org/subsound/ui/components/SongDownloadStatusIcon.java:44
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1370
-#, java-printf-format
-msgid "Available offline"
-msgstr ""
-
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:693
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:697
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:700
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:705
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:684
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:688
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:691
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:696
 #, java-printf-format
 msgid "%d item"
 msgid_plural "%d items"
@@ -501,166 +495,211 @@ msgstr ""
 msgid "Configuration saved!"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:76
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:84
 #, java-printf-format
 msgid "Clear song cache"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:80
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:88
 #, java-printf-format
 msgid "Clear thumbnail cache"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:84
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:92
 #, java-printf-format
 msgid "Clear lyrics cache"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:89
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:97
 #, java-printf-format
 msgid "Local Settings"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:99
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:123
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:107
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:131
 #, java-printf-format
 msgid "Source"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:116
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:124
 #, java-printf-format
 msgid "Audio format"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:127
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:135
 #, java-printf-format
 msgid "Max bitrate"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:153
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:161
 #, java-printf-format
 msgid "Server information"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:155
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:163
 #, java-printf-format
 msgid "Type"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:156
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:164
 #, java-printf-format
 msgid "Version"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:157
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:165
 #, java-printf-format
 msgid "API Version"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:158
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:166
 #, java-printf-format
 msgid "OpenSubsonic support"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:163
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:171
 #, java-printf-format
 msgid "OpenSubsonic extensions"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:168
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:176
 #, java-printf-format
 msgid "Transcode Settings"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:174
-#, java-printf-format
-msgid "Full scan"
-msgstr ""
-
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:176
-#, java-printf-format
-msgid "Start server scan for new songs and folders"
-msgstr ""
-
 #: src/main/java/org/subsound/ui/components/SettingsPage.java:184
 #, java-printf-format
-msgid "Quick scan"
+msgid "Enable ReplayGain"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:186
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:185
 #, java-printf-format
-msgid "Start server quick scan for new songs and folders"
+msgid "Normalize playback loudness across tracks"
+msgstr ""
+
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:190
+#, java-printf-format
+msgid "Track"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/components/SettingsPage.java:193
 #, java-printf-format
-msgid "Last Scanned at"
+msgid "Normalization mode"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/components/SettingsPage.java:194
 #, java-printf-format
-msgid "Status"
+msgid "Album mode preserves an album's internal dynamics"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:195
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:199
 #, java-printf-format
-msgid "Server songs"
+msgid "Pre-amp (dB)"
+msgstr ""
+
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:204
+#, java-printf-format
+msgid "Fallback gain (dB)"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/components/SettingsPage.java:205
 #, java-printf-format
+msgid "Applied to tracks without ReplayGain data"
+msgstr ""
+
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:210
+#, java-printf-format
+msgid "ReplayGain"
+msgstr ""
+
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:228
+#, java-printf-format
+msgid "Full scan"
+msgstr ""
+
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:230
+#, java-printf-format
+msgid "Start server scan for new songs and folders"
+msgstr ""
+
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:238
+#, java-printf-format
+msgid "Quick scan"
+msgstr ""
+
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:240
+#, java-printf-format
+msgid "Start server quick scan for new songs and folders"
+msgstr ""
+
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:247
+#, java-printf-format
+msgid "Last Scanned at"
+msgstr ""
+
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:248
+#, java-printf-format
+msgid "Status"
+msgstr ""
+
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:249
+#, java-printf-format
+msgid "Server songs"
+msgstr ""
+
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:259
+#, java-printf-format
 msgid "Local songs"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:209
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:263
 #, java-printf-format
 msgid "Sync library"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:211
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:265
 #, java-printf-format
 msgid "Syncs metadata for offline use"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:226
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:280
 #, java-printf-format
 msgid "Local Library"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:284
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:285
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:359
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:360
 #, java-printf-format
 msgid "Unknown"
 msgstr "Ukjent"
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:287
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:362
 #, java-printf-format
 msgid "No"
 msgstr "Nei"
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:287
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:362
 #, java-printf-format
 msgid "Yes"
 msgstr "Ja"
 
 #: src/main/java/org/subsound/ui/components/SongContextMenu.java:68
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:417
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:718
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1604
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1334
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1657
 #, java-printf-format
 msgid "Play"
 msgstr "Spill av"
 
 #: src/main/java/org/subsound/ui/components/SongContextMenu.java:74
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:438
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1627
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1680
 #, java-printf-format
 msgid "Play Next"
 msgstr "Spill neste"
 
 #: src/main/java/org/subsound/ui/components/SongContextMenu.java:80
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:444
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1633
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1686
 #, java-printf-format
 msgid "Add to Queue"
 msgstr "Legg til i kø"
@@ -673,19 +712,25 @@ msgstr "Legg til i favoritter"
 #: src/main/java/org/subsound/ui/components/SongContextMenu.java:101
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:459
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:673
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:722
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1639
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1338
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1692
 #, java-printf-format
 msgid "Add to Playlist…"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/components/SongContextMenu.java:112
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:464
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:729
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1642
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1340
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1695
 #, java-printf-format
 msgid "Download"
 msgstr "Last ned"
+
+#: src/main/java/org/subsound/ui/components/SongDownloadStatusIcon.java:44
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1423
+#, java-printf-format
+msgid "Available offline"
+msgstr ""
 
 #: src/main/java/org/subsound/ui/components/SongDownloadStatusIcon.java:50
 #, java-printf-format
@@ -719,13 +764,13 @@ msgid "Add to Starred"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:450
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:733
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1344
 #, java-printf-format
 msgid "Unstar"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:490
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1683
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1736
 #, java-printf-format
 msgid "← Back"
 msgstr ""
@@ -738,7 +783,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:658
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1334
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1387
 #, java-printf-format
 msgid "Download all"
 msgstr "Last ned alle"
@@ -812,98 +857,98 @@ msgstr[1] ""
 msgid "Scanned %s ago"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:264
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:263
 #, java-printf-format
 msgid "Filter by title, artist, or album"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:390
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:942
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:389
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:911
 #, java-printf-format
 msgid "Title"
 msgstr "Tittel"
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:499
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:498
 #, java-printf-format
 msgid "Duration"
 msgstr "Lengde"
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:681
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:680
 #, java-printf-format
 msgid "Refresh playlist"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:704
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1320
 #, java-printf-format
 msgid "Clear selection"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:720
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1336
 #, fuzzy, java-printf-format
 msgid "Add to queue"
 msgstr "Legg til i kø"
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:731
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1342
 #, fuzzy, java-printf-format
 msgid "Star"
 msgstr "Favoritter"
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:735
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:803
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1655
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1346
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1374
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1708
 #, java-printf-format
 msgid "Remove from Playlist"
 msgstr "Fjern fra spilleliste"
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:796
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1369
 #, fuzzy, java-printf-format
 msgid "%d selected"
 msgid_plural "%d selected"
 msgstr[0] "%d sek"
 msgstr[1] "%d sek"
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:802
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1664
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1373
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1717
 #, java-printf-format
 msgid "Remove from Downloads"
 msgstr "Fjern fra nedlastinger"
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1333
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1386
 #, java-printf-format
 msgid "Rename…"
 msgstr "Gi nytt navn…"
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1335
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1388
 #, java-printf-format
 msgid "Delete Playlist…"
 msgstr "Slett spilleliste…"
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1474
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1527
 #, java-printf-format
 msgid "Rename Playlist"
 msgstr "Gi nytt navn"
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1475
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1528
 #, java-printf-format
 msgid "Enter a new name for \"%s\""
 msgstr "Skriv inn nytt navn for '%s'"
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1479
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1532
 #, java-printf-format
 msgid "_Rename"
 msgstr "_Gi nytt navn"
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1518
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1571
 #, java-printf-format
 msgid "Delete Playlist"
 msgstr "Slett spilleliste"
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1519
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1572
 #, java-printf-format
 msgid "Delete \"%s\"? This cannot be undone."
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1523
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1576
 #, java-printf-format
 msgid "_Delete"
 msgstr "_Slett"

--- a/src/main/java/org/subsound/MainApplication.java
+++ b/src/main/java/org/subsound/MainApplication.java
@@ -297,7 +297,8 @@ public class MainApplication {
                         this.appManager,
                         info,
                         cfg.dataDir,
-                        transcodeSettings
+                        transcodeSettings,
+                        this.appManager.getReplayGainConfig()
                 );
                 NavigationPage navPage = NavigationPage.builder().setChild(settings).setTitle(tr("Settings")).build();
                 navigationView.push(navPage);

--- a/src/main/java/org/subsound/app/state/AppManager.java
+++ b/src/main/java/org/subsound/app/state/AppManager.java
@@ -127,6 +127,9 @@ public class AppManager {
     // because setSource/seek reset the live value before the transition's listener fire lands.
     private final AtomicReference<Observation> lastObservation = new AtomicReference<>();
     private final AtomicInteger loadGeneration = new java.util.concurrent.atomic.AtomicInteger(0);
+    // Cached per-server ReplayGain settings, used to compute the playback gain for each song
+    // without a DB hit per track. Refreshed on startup and whenever the settings are saved.
+    private volatile ServerClient.ReplayGainConfig replayGainConfig = ServerClient.ReplayGainConfig.defaultConfig();
 
     private Optional<ApplicationWindow> window = Optional.empty();
     private ToastOverlay toastOverlay;
@@ -157,6 +160,9 @@ public class AppManager {
                 UUID.fromString(savedServerId),
                 this.database
         );
+        this.replayGainConfig = this.databaseService.getServerById(savedServerId)
+                .map(Server::replayGainConfig)
+                .orElseGet(ServerClient.ReplayGainConfig::defaultConfig);
         // Load server configuration from DB (or migrate from legacy JSON)
         this.client = new AtomicReference<>();
         this.songCache = new SongCache(
@@ -305,7 +311,8 @@ public class AppManager {
                     false,
                     legacy.audioFormat(),
                     legacy.transcodeBitrate(),
-                    List.of()
+                    List.of(),
+                    ServerClient.ReplayGainConfig.defaultConfig()
             );
             this.databaseService.insert(server);
             config.legacyServerConfig = null;
@@ -834,7 +841,11 @@ public class AppManager {
         }
         boolean startPlaying = !startPaused;
         this.player.setSource(
-                new AudioSource(cachedSong.uri(), songInfo.duration()),
+                new AudioSource(
+                        cachedSong.uri(),
+                        songInfo.duration(),
+                        computeReplayGainScale(songInfo, this.replayGainConfig)
+                ),
                 startPlaying
         );
         // Commit the scrobble session for this song. setSource has already reset
@@ -944,6 +955,7 @@ public class AppManager {
                 // config actions:
                 case PlayerAction.SaveConfig settings -> this.saveConfig(settings);
                 case PlayerAction.SaveTranscodeFormat a -> this.saveTranscodeFormat(a);
+                case PlayerAction.SaveReplayGainConfig a -> this.saveReplayGainConfig(a);
                 case PlayerAction.Toast t -> this.toast(t);
 
                 // player actions:
@@ -1176,6 +1188,9 @@ public class AppManager {
         String existingAudioFormat = null;
         Integer existingAudioBitrate = null;
         var existingServer = this.databaseService.getServerById(SERVER_ID);
+        ServerClient.ReplayGainConfig existingReplayGain = existingServer
+                .map(Server::replayGainConfig)
+                .orElseGet(ServerClient.ReplayGainConfig::defaultConfig);
         if (existingServer.isPresent()) {
             existingAudioFormat = existingServer.get().audioFormat();
             existingAudioBitrate = existingServer.get().audioBitrate();
@@ -1192,7 +1207,8 @@ public class AppManager {
                 settings.next().tlsSkipVerify(),
                 existingAudioFormat,
                 existingAudioBitrate,
-                settings.next().customHeaders()
+                settings.next().customHeaders(),
+                existingReplayGain
         );
         this.databaseService.upsert(server);
 
@@ -1246,7 +1262,7 @@ public class AppManager {
                 server.id(), server.isPrimary(), server.serverType(),
                 server.serverUrl(), server.username(), server.createdAt(),
                 server.tlsSkipVerify(), audioFormatStr, audioBitrateInt,
-                server.customHeaders()
+                server.customHeaders(), server.replayGainConfig()
         );
         this.databaseService.upsert(updatedServer);
 
@@ -1262,6 +1278,63 @@ public class AppManager {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /** Current per-server ReplayGain settings (cached; reflects the latest save). */
+    public ServerClient.ReplayGainConfig getReplayGainConfig() {
+        return this.replayGainConfig;
+    }
+
+    private void saveReplayGainConfig(PlayerAction.SaveReplayGainConfig action) {
+        // Persist per-server; ReplayGain only affects local playback, so unlike transcode
+        // settings there is no need to rebuild the runtime config or recreate the client.
+        var serverOpt = this.databaseService.getServerById(this.dbService.getServerId().toString());
+        if (serverOpt.isPresent()) {
+            var server = serverOpt.get();
+            var updatedServer = new Server(
+                    server.id(), server.isPrimary(), server.serverType(),
+                    server.serverUrl(), server.username(), server.createdAt(),
+                    server.tlsSkipVerify(), server.audioFormat(), server.audioBitrate(),
+                    server.customHeaders(), action.config()
+            );
+            this.databaseService.upsert(updatedServer);
+        }
+        this.replayGainConfig = action.config();
+
+        // Apply immediately to whatever is playing so the change is audible without a track skip.
+        this.currentState.getValue().nowPlaying()
+                .map(NowPlaying::song)
+                .ifPresent(song -> this.player.setReplayGainScale(
+                        computeReplayGainScale(song, action.config())
+                ));
+    }
+
+    /**
+     * Effective linear volume multiplier for a song under the given ReplayGain settings.
+     * Returns 1.0 (no change) when disabled. Songs without ReplayGain metadata use the
+     * configured fallback gain. A peak-based clamp prevents a boosted track from clipping.
+     */
+    static double computeReplayGainScale(SongInfo song, ServerClient.ReplayGainConfig config) {
+        if (!config.enabled()) {
+            return 1.0;
+        }
+        boolean albumMode = config.mode() == ServerClient.ReplayGainConfig.Mode.ALBUM;
+        double gainDb = song.replayGain()
+                .map(rg -> albumMode ? rg.albumGain() : rg.trackGain())
+                .orElse(config.fallbackGainDb());
+        gainDb += config.preAmpDb();
+
+        double linear = Math.pow(10.0, gainDb / 20.0);
+
+        // Prevent clipping: if the boosted peak would exceed full scale, cap the gain so the
+        // loudest sample lands exactly at 1.0. Only possible when we actually know the peak.
+        double peak = song.replayGain()
+                .map(rg -> albumMode ? rg.albumPeak() : rg.trackPeak())
+                .orElse(0.0);
+        if (peak > 0.0 && linear * peak > 1.0) {
+            linear = 1.0 / peak;
+        }
+        return linear;
     }
 
     private void setClient(ServerClient newClient) {

--- a/src/main/java/org/subsound/app/state/PlayerAction.java
+++ b/src/main/java/org/subsound/app/state/PlayerAction.java
@@ -62,6 +62,7 @@ public sealed interface PlayerAction {
     // not strictly player actions:
     record SaveConfig(SettingsInfo next) implements PlayerAction {}
     record SaveTranscodeFormat(ServerClient.TranscodeSettings audioFormat) implements PlayerAction {}
+    record SaveReplayGainConfig(ServerClient.ReplayGainConfig config) implements PlayerAction {}
     record Toast(org.gnome.adw.Toast toast, Duration timeout) implements PlayerAction {
         public Toast(org.gnome.adw.Toast toast) {
             this(toast, Duration.ofMillis(2000));

--- a/src/main/java/org/subsound/integration/ServerClient.java
+++ b/src/main/java/org/subsound/integration/ServerClient.java
@@ -172,6 +172,21 @@ public interface ServerClient {
     record CoverArtResponse(byte[] data, String contentType) {}
 
     record ArtistId(String id, String name) {}
+
+    /**
+     * ReplayGain loudness-normalization metadata for a single song, as exposed by
+     * OpenSubsonic servers. Gains are in dB; peaks are linear sample values (0.0-1.0+).
+     * Always carried as an {@link Optional} on {@link SongInfo}: a song may have no
+     * ReplayGain tags, and cached songs synced before this metadata existed read back
+     * as absent until re-synced.
+     */
+    record ReplayGain(
+            double trackGain,
+            double albumGain,
+            double trackPeak,
+            double albumPeak
+    ) {}
+
     @RecordBuilderFull
     record SongInfo(
             String id,
@@ -182,6 +197,7 @@ public interface ServerClient {
             long size,
             Optional<Integer> year,
             String genre,
+            //List<String> genres,
             Long playCount,
             Optional<Integer> userRating,
             ArtistId mainArtist,
@@ -196,7 +212,8 @@ public interface ServerClient {
             Optional<CoverArt> coverArt,
             String suffix,
             TranscodeInfo transcodeInfo,
-            URI downloadUri
+            URI downloadUri,
+            Optional<ReplayGain> replayGain
     ) implements ServerClientSongInfoBuilder.With {
         public String artistName() {
             return mainArtist.name();
@@ -448,6 +465,31 @@ public interface ServerClient {
             TranscodeFormat format,
             TranscodeBitrate bitrate
     ) {}
+
+    /**
+     * Per-server ReplayGain (loudness normalization) preferences.
+     *
+     * @param enabled       master on/off for normalization
+     * @param mode          whether to use per-track gain (even loudness across shuffle) or
+     *                      album gain (preserves an album's internal dynamics)
+     * @param preAmpDb      fixed dB offset applied on top of the chosen gain
+     * @param fallbackGainDb gain in dB applied to songs that have no ReplayGain metadata
+     */
+    record ReplayGainConfig(
+            boolean enabled,
+            Mode mode,
+            double preAmpDb,
+            double fallbackGainDb
+    ) {
+        public enum Mode {
+            TRACK,
+            ALBUM,
+        }
+
+        public static ReplayGainConfig defaultConfig() {
+            return new ReplayGainConfig(false, Mode.TRACK, 0.0, 0.0);
+        }
+    }
     /** A custom HTTP header attached to every request to the server (e.g. Cloudflare Access headers). */
     record HttpHeader(
             String name,

--- a/src/main/java/org/subsound/integration/servers/subsonic/SubsonicClientV2.java
+++ b/src/main/java/org/subsound/integration/servers/subsonic/SubsonicClientV2.java
@@ -700,7 +700,13 @@ public class SubsonicClientV2 implements ServerClient {
                 toCoverArt(song.albumId(), new AlbumIdentifier(song.albumId())),
                 song.suffix() != null ? song.suffix() : "",
                 transcodeInfo,
-                downloadUri
+                downloadUri,
+                ofNullable(song.replayGain()).map(rg -> new ReplayGain(
+                        rg.trackGain(),
+                        rg.albumGain(),
+                        rg.trackPeak(),
+                        rg.albumPeak()
+                ))
         );
     }
 

--- a/src/main/java/org/subsound/persistence/CachingClient.java
+++ b/src/main/java/org/subsound/persistence/CachingClient.java
@@ -621,7 +621,8 @@ public class CachingClient implements ServerClient {
                 song.coverArtId().flatMap(id -> toCoverArt(song.albumId(), new ObjectIdentifier.AlbumIdentifier(song.albumId()))),
                 streamFormat,
                 transcodeInfo,
-                URI.create("offline://unavailable/" + song.id())
+                URI.create("offline://unavailable/" + song.id()),
+                song.replayGain()
         );
     }
 

--- a/src/main/java/org/subsound/persistence/database/DBSong.java
+++ b/src/main/java/org/subsound/persistence/database/DBSong.java
@@ -2,6 +2,7 @@ package org.subsound.persistence.database;
 
 import org.subsound.integration.ServerClient.ArtistId;
 import org.subsound.integration.ServerClient.CoverArt;
+import org.subsound.integration.ServerClient.ReplayGain;
 import org.subsound.integration.ServerClient.SongInfo;
 
 import java.time.Duration;
@@ -31,7 +32,8 @@ public record DBSong(
         String suffix,
         Optional<List<ArtistId>> artists,
         Optional<List<ArtistId>> albumArtists,
-        List<String> moods
+        List<String> moods,
+        Optional<ReplayGain> replayGain
 ) {
     public static DBSong from(SongInfo songInfo, UUID serverId) {
         return new DBSong(
@@ -55,7 +57,8 @@ public record DBSong(
                 songInfo.suffix(),
                 songInfo.artists(),
                 songInfo.albumArtists(),
-                songInfo.moods()
+                songInfo.moods(),
+                songInfo.replayGain()
         );
     }
 }

--- a/src/main/java/org/subsound/persistence/database/Database.java
+++ b/src/main/java/org/subsound/persistence/database/Database.java
@@ -142,6 +142,7 @@ public class Database {
         migrations.add(new MigrationV20());
         migrations.add(new MigrationV21());
         migrations.add(new MigrationV22());
+        migrations.add(new MigrationV23());
         return migrations;
     }
 
@@ -712,6 +713,28 @@ public class Database {
                             PRIMARY KEY (playlist_id, server_id)
                         )
                         """);
+            }
+        }
+    }
+
+    static class MigrationV23 implements Migration {
+        @Override
+        public int version() { return 23; }
+
+        @Override
+        public void apply(Connection conn) throws SQLException {
+            try (Statement stmt = conn.createStatement()) {
+                // ReplayGain loudness-normalization metadata (OpenSubsonic). Gains in dB, peaks
+                // linear. NULL for rows synced before this migration; such songs simply play with
+                // the configured fallback gain until re-synced.
+                stmt.execute("ALTER TABLE songs ADD COLUMN rg_track_gain REAL");
+                stmt.execute("ALTER TABLE songs ADD COLUMN rg_album_gain REAL");
+                stmt.execute("ALTER TABLE songs ADD COLUMN rg_track_peak REAL");
+                stmt.execute("ALTER TABLE songs ADD COLUMN rg_album_peak REAL");
+
+                // Per-server ReplayGain settings (enabled/mode/pre-amp/fallback), stored as one
+                // JSON blob. NULL for existing servers -> treated as defaults.
+                stmt.execute("ALTER TABLE servers ADD COLUMN replaygain_config_json TEXT");
             }
         }
     }

--- a/src/main/java/org/subsound/persistence/database/DatabaseServerService.java
+++ b/src/main/java/org/subsound/persistence/database/DatabaseServerService.java
@@ -3,6 +3,7 @@ package org.subsound.persistence.database;
 import com.google.gson.reflect.TypeToken;
 import org.subsound.integration.ServerClient;
 import org.subsound.integration.ServerClient.ArtistId;
+import org.subsound.integration.ServerClient.ReplayGain;
 import org.subsound.persistence.database.Artist.Biography;
 import org.subsound.integration.ServerClient.SongInfo;
 import org.subsound.persistence.database.DownloadQueueItem.DownloadStatus;
@@ -334,8 +335,8 @@ public class DatabaseServerService {
     }
 
     private static final String SONG_INSERT_SQL = """
-            INSERT OR REPLACE INTO songs (id, server_id, album_id, album_name, name, year, artist_id, artist_name, duration_ms, starred_at_ms, cover_art_id, created_at_ms, track_number, disc_number, bit_rate, size, genre, suffix, artists_json, album_artists_json, moods_json, search_text)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT OR REPLACE INTO songs (id, server_id, album_id, album_name, name, year, artist_id, artist_name, duration_ms, starred_at_ms, cover_art_id, created_at_ms, track_number, disc_number, bit_rate, size, genre, suffix, artists_json, album_artists_json, moods_json, rg_track_gain, rg_album_gain, rg_track_peak, rg_album_peak, search_text)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """;
 
     private static void bindSong(PreparedStatement pstmt, DBSong song) throws SQLException {
@@ -396,7 +397,19 @@ public class DatabaseServerService {
         } else {
             pstmt.setNull(21, Types.VARCHAR);
         }
-        pstmt.setString(22, SearchNormalizer.normalizeIndexText(song.name(), song.artistName(), song.albumName()));
+        if (song.replayGain().isPresent()) {
+            var rg = song.replayGain().get();
+            pstmt.setDouble(22, rg.trackGain());
+            pstmt.setDouble(23, rg.albumGain());
+            pstmt.setDouble(24, rg.trackPeak());
+            pstmt.setDouble(25, rg.albumPeak());
+        } else {
+            pstmt.setNull(22, Types.REAL);
+            pstmt.setNull(23, Types.REAL);
+            pstmt.setNull(24, Types.REAL);
+            pstmt.setNull(25, Types.REAL);
+        }
+        pstmt.setString(26, SearchNormalizer.normalizeIndexText(song.name(), song.artistName(), song.albumName()));
     }
 
     public void insert(DBSong song) {
@@ -702,6 +715,7 @@ public class DatabaseServerService {
         Optional<List<ArtistId>> artists = parseArtistList(rs.getString("artists_json"));
         Optional<List<ArtistId>> albumArtists = parseArtistList(rs.getString("album_artists_json"));
         List<String> moods = parseMoodList(rs.getString("moods_json"));
+        Optional<ReplayGain> replayGain = parseReplayGain(rs);
 
         return new DBSong(
                 rs.getString("id"),
@@ -724,8 +738,24 @@ public class DatabaseServerService {
                 rs.getString("suffix") != null ? rs.getString("suffix") : "",
                 artists,
                 albumArtists,
-                moods
+                moods,
+                replayGain
         );
+    }
+
+    /**
+     * Reconstruct ReplayGain from the four nullable REAL columns. Absent (empty) when the
+     * gains were never synced (rows predating MigrationV23) — the gain columns are NULL.
+     */
+    private static Optional<ReplayGain> parseReplayGain(ResultSet rs) throws SQLException {
+        double trackGain = rs.getDouble("rg_track_gain");
+        if (rs.wasNull()) {
+            return Optional.empty();
+        }
+        double albumGain = rs.getDouble("rg_album_gain");
+        double trackPeak = rs.getDouble("rg_track_peak");
+        double albumPeak = rs.getDouble("rg_album_peak");
+        return Optional.of(new ReplayGain(trackGain, albumGain, trackPeak, albumPeak));
     }
 
     private static Optional<List<ArtistId>> parseArtistList(String json) {

--- a/src/main/java/org/subsound/persistence/database/DatabaseService.java
+++ b/src/main/java/org/subsound/persistence/database/DatabaseService.java
@@ -2,6 +2,7 @@ package org.subsound.persistence.database;
 
 import com.google.gson.reflect.TypeToken;
 import org.subsound.integration.ServerClient.HttpHeader;
+import org.subsound.integration.ServerClient.ReplayGainConfig;
 import org.subsound.integration.ServerClient.ServerType;
 import org.subsound.utils.Utils;
 import org.slf4j.Logger;
@@ -23,7 +24,7 @@ public class DatabaseService {
     private static final Logger logger = LoggerFactory.getLogger(DatabaseService.class);
     private final Database database;
 
-    private static final String ALL_COLUMNS = "id, is_primary, server_type, server_url, username, created_at, tls_skip_verify, audio_format, audio_bitrate, custom_headers";
+    private static final String ALL_COLUMNS = "id, is_primary, server_type, server_url, username, created_at, tls_skip_verify, audio_format, audio_bitrate, custom_headers, replaygain_config_json";
 
     public DatabaseService(Database database) {
         this.database = database;
@@ -40,7 +41,7 @@ public class DatabaseService {
     }
 
     public void insert(Server server) {
-        String sql = "INSERT INTO servers (" + ALL_COLUMNS + ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+        String sql = "INSERT INTO servers (" + ALL_COLUMNS + ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
         try (Connection conn = database.openConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql)) {
             setServerParams(pstmt, server);
@@ -53,7 +54,7 @@ public class DatabaseService {
 
     public void upsert(Server server) {
         String sql = """
-            INSERT INTO servers (%s) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO servers (%s) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(id) DO UPDATE SET
                 is_primary = excluded.is_primary,
                 server_type = excluded.server_type,
@@ -62,7 +63,8 @@ public class DatabaseService {
                 tls_skip_verify = excluded.tls_skip_verify,
                 audio_format = excluded.audio_format,
                 audio_bitrate = excluded.audio_bitrate,
-                custom_headers = excluded.custom_headers
+                custom_headers = excluded.custom_headers,
+                replaygain_config_json = excluded.replaygain_config_json
             """.formatted(ALL_COLUMNS);
         try (Connection conn = database.openConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql)) {
@@ -142,6 +144,10 @@ public class DatabaseService {
         }
         var customHeaders = server.customHeaders() == null ? List.of() : server.customHeaders();
         pstmt.setString(10, Utils.toJson(customHeaders));
+        var replayGainConfig = server.replayGainConfig() == null
+                ? ReplayGainConfig.defaultConfig()
+                : server.replayGainConfig();
+        pstmt.setString(11, Utils.toJson(replayGainConfig));
     }
 
     private Server mapResultSetToServer(ResultSet rs) throws SQLException {
@@ -157,8 +163,17 @@ public class DatabaseService {
                 rs.getBoolean("tls_skip_verify"),
                 rs.getString("audio_format"),
                 audioBitrate,
-                parseHttpHeaders(rs.getString("custom_headers"))
+                parseHttpHeaders(rs.getString("custom_headers")),
+                parseReplayGainConfig(rs.getString("replaygain_config_json"))
         );
+    }
+
+    private static ReplayGainConfig parseReplayGainConfig(String json) {
+        if (json == null || json.isBlank()) {
+            return ReplayGainConfig.defaultConfig();
+        }
+        ReplayGainConfig config = Utils.fromJson(json, ReplayGainConfig.class);
+        return config == null ? ReplayGainConfig.defaultConfig() : config;
     }
 
     private static final Type HTTP_HEADER_LIST_TYPE = new TypeToken<List<HttpHeader>>() {}.getType();

--- a/src/main/java/org/subsound/persistence/database/Server.java
+++ b/src/main/java/org/subsound/persistence/database/Server.java
@@ -2,6 +2,7 @@ package org.subsound.persistence.database;
 
 import org.jspecify.annotations.Nullable;
 import org.subsound.integration.ServerClient.HttpHeader;
+import org.subsound.integration.ServerClient.ReplayGainConfig;
 import org.subsound.integration.ServerClient.ServerType;
 
 import java.time.Instant;
@@ -18,6 +19,7 @@ public record Server(
         boolean tlsSkipVerify,
         @Nullable String audioFormat,
         @Nullable Integer audioBitrate,
-        List<HttpHeader> customHeaders
+        List<HttpHeader> customHeaders,
+        ReplayGainConfig replayGainConfig
 ) {
 }

--- a/src/main/java/org/subsound/sound/PlaybinPlayer.java
+++ b/src/main/java/org/subsound/sound/PlaybinPlayer.java
@@ -163,6 +163,12 @@ public class PlaybinPlayer implements Player {
     private final MainContext playerContext;
     private final MainLoop loop;
     Element playbinEl;
+    // ReplayGain gain stage inserted via playbin's "audio-filter". Its "volume" property carries
+    // the per-track normalization multiplier and multiplies with playbin's own user-volume. Null
+    // if the "volume" element could not be created (playback then proceeds without normalization).
+    private Element replayGainVolumeEl;
+    // Last applied ReplayGain multiplier; re-applied after each READY bounce in setSource.
+    private volatile double replayGainScale = 1.0;
     Bus bus;
     int busWatchId;
     // macOS-only. osxAudioSink is the sink we install as playbin's audio-sink. deviceMonitor is an
@@ -210,11 +216,29 @@ public class PlaybinPlayer implements Player {
 
     public record AudioSource(
             URI uri,
-            Duration estimatedDuration
-    ){}
+            Duration estimatedDuration,
+            // ReplayGain linear volume multiplier for this track (1.0 = no change).
+            double replayGainScale
+    ){
+        public AudioSource(URI uri, Duration estimatedDuration) {
+            this(uri, estimatedDuration, 1.0);
+        }
+    }
     public void setSource(AudioSource src, boolean startPlaying) {
         this.duration = src.estimatedDuration;
+        this.replayGainScale = src.replayGainScale;
         this.setSource(src.uri, startPlaying);
+    }
+
+    /**
+     * Update the ReplayGain multiplier for the currently-playing track without restarting it.
+     * The "volume" element's property is live-controllable, so the change takes effect immediately.
+     */
+    public void setReplayGainScale(double scale) {
+        this.replayGainScale = scale;
+        if (this.replayGainVolumeEl != null) {
+            this.replayGainVolumeEl.set("volume", scale, null);
+        }
     }
 
     public void setSource(URI uri, boolean startPlaying) {
@@ -243,6 +267,10 @@ public class PlaybinPlayer implements Player {
         // Restore volume after state change
         this.playbinEl.set("volume", savedVolume, null);
         this.playbinEl.set("mute", savedMute, null);
+        // Apply this track's ReplayGain multiplier (independent of the user volume above).
+        if (this.replayGainVolumeEl != null) {
+            this.replayGainVolumeEl.set("volume", this.replayGainScale, null);
+        }
         if (startPlaying) {
             var playing = this.playbinEl.setState(State.PLAYING);
             log.debug("Player: Change source to src=" + fileUri + ": PLAYING=" + playing.name());
@@ -590,6 +618,19 @@ public class PlaybinPlayer implements Player {
             flags = flags | GST_PLAY_FLAG_SOFT_VOLUME;
         }
         playbinEl.set("flags", flags, null);
+
+        // ReplayGain: insert a "volume" element as playbin's audio-filter. We compute the
+        // normalization multiplier ourselves (from the server's ReplayGain dB values) and drive
+        // this element's "volume" property; it multiplies with playbin's own user-facing volume,
+        // so the two stay independent. "volume" is a gst-plugins-base core element (always present)
+        // and its "volume" property is live-controllable. The audio-filter is only picked up while
+        // playbin is in NULL/READY, which is where we are here at construction.
+        replayGainVolumeEl = ElementFactory.make("volume", "replaygain-volume");
+        if (replayGainVolumeEl != null) {
+            playbinEl.set("audio-filter", replayGainVolumeEl, null);
+        } else {
+            log.warn("Could not create 'volume' element; ReplayGain normalization disabled");
+        }
 
         // We add a message handler
         bus = playbinEl.getBus();

--- a/src/main/java/org/subsound/ui/components/SettingsPage.java
+++ b/src/main/java/org/subsound/ui/components/SettingsPage.java
@@ -5,6 +5,8 @@ import org.gnome.adw.ButtonRow;
 import org.gnome.adw.Clamp;
 import org.gnome.adw.ComboRow;
 import org.gnome.adw.PreferencesGroup;
+import org.gnome.adw.SpinRow;
+import org.gnome.adw.SwitchRow;
 import org.gnome.gtk.Align;
 import org.gnome.gtk.Box;
 import org.gnome.gtk.Image;
@@ -16,6 +18,7 @@ import org.subsound.app.state.AppManager;
 import org.subsound.app.state.NetworkMonitoring.NetworkStatus;
 import org.subsound.app.state.PlayerAction;
 import org.subsound.integration.ServerClient;
+import org.subsound.integration.ServerClient.ReplayGainConfig;
 import org.subsound.integration.ServerClient.TranscodeBitrate.MaximumBitrate;
 import org.subsound.integration.ServerClient.TranscodeBitrate.SourceQuality;
 import org.subsound.integration.ServerClient.TranscodeSettings;
@@ -51,6 +54,11 @@ public class SettingsPage extends Box {
     private final PreferencesGroup transcodeSettings;
     private final ComboRow audioFormatCombo;
     private final ComboRow audioBitrateCombo;
+    private final PreferencesGroup replayGainSettings;
+    private final SwitchRow rgEnabledSwitch;
+    private final ComboRow rgModeCombo;
+    private final SpinRow rgPreAmpSpin;
+    private final SpinRow rgFallbackSpin;
     private final PreferencesGroup serverLibrary;
     private final ButtonRow librarySyncRow;
     private final ButtonRow libraryQuickScanRow;
@@ -67,7 +75,8 @@ public class SettingsPage extends Box {
             AppManager appManager,
             @Nullable SettingsInfo settingsInfo,
             Path dataDir,
-            @Nullable TranscodeSettings transcodeSettings
+            @Nullable TranscodeSettings transcodeSettings,
+            ReplayGainConfig replayGainConfig
     ) {
         super(VERTICAL, 0);
         this.appManager = appManager;
@@ -170,6 +179,54 @@ public class SettingsPage extends Box {
         this.transcodeSettings.add(audioFormatCombo);
         this.transcodeSettings.add(audioBitrateCombo);
 
+        // ReplayGain (loudness normalization) settings, stored per server. Seeded from the
+        // caller (mirroring transcodeSettings); AppManager remains the owner and pushes changes
+        // to the player.
+        var rgConfig = replayGainConfig != null ? replayGainConfig : ReplayGainConfig.defaultConfig();
+        this.rgEnabledSwitch = SwitchRow.builder()
+                .setTitle(tr("Enable ReplayGain"))
+                .setSubtitle(tr("Normalize playback loudness across tracks"))
+                .build();
+        this.rgEnabledSwitch.setActive(rgConfig.enabled());
+
+        var rgModeModel = new StringList();
+        rgModeModel.append(tr("Track"));
+        rgModeModel.append(tr("Album"));
+        this.rgModeCombo = new ComboRow();
+        this.rgModeCombo.setTitle(tr("Normalization mode"));
+        this.rgModeCombo.setSubtitle(tr("Album mode preserves an album's internal dynamics"));
+        this.rgModeCombo.setModel(rgModeModel);
+        this.rgModeCombo.setSelected(rgConfig.mode() == ReplayGainConfig.Mode.ALBUM ? 1 : 0);
+
+        this.rgPreAmpSpin = SpinRow.withRange(-15.0, 15.0, 0.5);
+        this.rgPreAmpSpin.setTitle(tr("Pre-amp (dB)"));
+        this.rgPreAmpSpin.setDigits(1);
+        this.rgPreAmpSpin.setValue(rgConfig.preAmpDb());
+
+        this.rgFallbackSpin = SpinRow.withRange(-15.0, 15.0, 0.5);
+        this.rgFallbackSpin.setTitle(tr("Fallback gain (dB)"));
+        this.rgFallbackSpin.setSubtitle(tr("Applied to tracks without ReplayGain data"));
+        this.rgFallbackSpin.setDigits(1);
+        this.rgFallbackSpin.setValue(rgConfig.fallbackGainDb());
+
+        this.replayGainSettings = new PreferencesGroup();
+        this.replayGainSettings.setTitle(tr("ReplayGain"));
+        this.replayGainSettings.setSeparateRows(false);
+        this.replayGainSettings.add(rgEnabledSwitch);
+        this.replayGainSettings.add(rgModeCombo);
+        this.replayGainSettings.add(rgPreAmpSpin);
+        this.replayGainSettings.add(rgFallbackSpin);
+
+        // Wire change handlers AFTER setting initial values to avoid a spurious save on load.
+        this.rgEnabledSwitch.onNotify("active", _ -> {
+            applyReplayGainSensitivity();
+            saveReplayGain();
+        });
+        this.rgModeCombo.onNotify("selected", _ -> saveReplayGain());
+        this.rgPreAmpSpin.getAdjustment().onValueChanged(this::saveReplayGain);
+        this.rgFallbackSpin.getAdjustment().onValueChanged(this::saveReplayGain);
+        applyReplayGainSensitivity();
+
         this.librarySyncRow = ButtonRow.builder()
                 .setTitle(tr("Full scan"))
                 .setActivatable(true)
@@ -249,6 +306,7 @@ public class SettingsPage extends Box {
         this.centerBox.append(this.serverLibrary);
         this.centerBox.append(this.syncGroup);
         this.centerBox.append(this.transcodeSettings);
+        this.centerBox.append(this.replayGainSettings);
         this.centerBox.append(this.localSettings);
 
         var clamp = new Clamp();
@@ -265,6 +323,26 @@ public class SettingsPage extends Box {
         this.append(scroll);
         this.refresh();
         this.refreshLocalCount();
+    }
+
+    private void applyReplayGainSensitivity() {
+        boolean enabled = this.rgEnabledSwitch.getActive();
+        this.rgModeCombo.setSensitive(enabled);
+        this.rgPreAmpSpin.setSensitive(enabled);
+        this.rgFallbackSpin.setSensitive(enabled);
+    }
+
+    private void saveReplayGain() {
+        var mode = this.rgModeCombo.getSelected() == 1
+                ? ReplayGainConfig.Mode.ALBUM
+                : ReplayGainConfig.Mode.TRACK;
+        var config = new ReplayGainConfig(
+                this.rgEnabledSwitch.getActive(),
+                mode,
+                this.rgPreAmpSpin.getValue(),
+                this.rgFallbackSpin.getValue()
+        );
+        this.appManager.handleAction(new PlayerAction.SaveReplayGainConfig(config));
     }
 
     private void refresh() {

--- a/src/main/java/org/subsound/ui/views/TestPlayerPage.java
+++ b/src/main/java/org/subsound/ui/views/TestPlayerPage.java
@@ -157,7 +157,8 @@ public class TestPlayerPage extends Box {
                             Duration.ofSeconds(121),
                             suffix
                     ),
-                    uri
+                    uri,
+                    Optional.empty()
             );
         }
     }

--- a/src/test/java/org/subsound/app/state/ReplayGainScaleTest.java
+++ b/src/test/java/org/subsound/app/state/ReplayGainScaleTest.java
@@ -1,0 +1,71 @@
+package org.subsound.app.state;
+
+import org.junit.Test;
+import org.subsound.integration.ServerClient.ReplayGain;
+import org.subsound.integration.ServerClient.ReplayGainConfig;
+import org.subsound.integration.ServerClient.ReplayGainConfig.Mode;
+import org.subsound.integration.ServerClient.SongInfo;
+import org.subsound.integration.ServerClientSongInfoBuilder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+public class ReplayGainScaleTest {
+
+    private static SongInfo song(ReplayGain replayGain) {
+        return ServerClientSongInfoBuilder.builder()
+                .id("song-1")
+                .title("Song One")
+                .replayGain(Optional.ofNullable(replayGain))
+                .build();
+    }
+
+    @Test
+    public void disabledReturnsUnity() {
+        var config = new ReplayGainConfig(false, Mode.TRACK, 6.0, -3.0);
+        // Even with metadata and a pre-amp, a disabled config must not touch the volume.
+        var s = song(new ReplayGain(-6.0, -4.0, 0.5, 0.5));
+        assertThat(AppManager.computeReplayGainScale(s, config)).isEqualTo(1.0);
+    }
+
+    @Test
+    public void trackModeUsesTrackGain() {
+        var config = new ReplayGainConfig(true, Mode.TRACK, 0.0, 0.0);
+        // -6 dB -> 10^(-6/20) ≈ 0.5012; peak 0.5 -> 0.25 boosted, no clip.
+        var s = song(new ReplayGain(-6.0, -12.0, 0.5, 0.5));
+        assertThat(AppManager.computeReplayGainScale(s, config)).isCloseTo(0.50119, within(1e-4));
+    }
+
+    @Test
+    public void albumModeUsesAlbumGain() {
+        var config = new ReplayGainConfig(true, Mode.ALBUM, 0.0, 0.0);
+        // album gain -12 dB -> 10^(-12/20) ≈ 0.2512.
+        var s = song(new ReplayGain(-6.0, -12.0, 0.5, 0.5));
+        assertThat(AppManager.computeReplayGainScale(s, config)).isCloseTo(0.25119, within(1e-4));
+    }
+
+    @Test
+    public void missingMetadataUsesFallbackGain() {
+        var config = new ReplayGainConfig(true, Mode.TRACK, 0.0, -3.0);
+        // no ReplayGain -> fallback -3 dB -> 10^(-3/20) ≈ 0.7079. No peak known -> no clamp.
+        assertThat(AppManager.computeReplayGainScale(song(null), config)).isCloseTo(0.70795, within(1e-4));
+    }
+
+    @Test
+    public void preAmpIsAdded() {
+        var config = new ReplayGainConfig(true, Mode.TRACK, 6.0, 0.0);
+        // 0 dB gain + 6 dB pre-amp -> 10^(6/20) ≈ 1.9953; peak 0.1 -> 0.199, no clip.
+        var s = song(new ReplayGain(0.0, 0.0, 0.1, 0.1));
+        assertThat(AppManager.computeReplayGainScale(s, config)).isCloseTo(1.99526, within(1e-4));
+    }
+
+    @Test
+    public void peakClampPreventsClipping() {
+        var config = new ReplayGainConfig(true, Mode.TRACK, 0.0, 0.0);
+        // +12 dB -> 10^(12/20) ≈ 3.981; peak 0.5 -> would reach ~1.99 (clip). Clamp to 1/0.5 = 2.0.
+        var s = song(new ReplayGain(12.0, 12.0, 0.5, 0.5));
+        assertThat(AppManager.computeReplayGainScale(s, config)).isCloseTo(2.0, within(1e-9));
+    }
+}

--- a/src/test/java/org/subsound/persistence/database/DatabaseServerServiceTest.java
+++ b/src/test/java/org/subsound/persistence/database/DatabaseServerServiceTest.java
@@ -203,7 +203,8 @@ public class DatabaseServerServiceTest {
                 "mp3",
                 Optional.empty(),
                 Optional.empty(),
-                List.of()
+                List.of(),
+                Optional.empty()
         );
 
         DBSong song2 = new DBSong(
@@ -227,7 +228,8 @@ public class DatabaseServerServiceTest {
                 "",
                 Optional.empty(),
                 Optional.empty(),
-                List.of()
+                List.of(),
+                Optional.empty()
         );
 
         DBSong song3 = new DBSong(
@@ -251,7 +253,8 @@ public class DatabaseServerServiceTest {
                 "flac",
                 Optional.empty(),
                 Optional.empty(),
-                List.of()
+                List.of(),
+                Optional.empty()
         );
 
         // Test insert
@@ -298,7 +301,8 @@ public class DatabaseServerServiceTest {
                 Optional.empty(), Optional.empty(), now,
                 Optional.of(1), Optional.of(1), Optional.of(320),
                 5000000L, "Rock", "mp3",
-                Optional.of(artists), Optional.of(albumArtists), moods
+                Optional.of(artists), Optional.of(albumArtists), moods,
+                Optional.empty()
         );
 
         service.insert(song);
@@ -317,7 +321,8 @@ public class DatabaseServerServiceTest {
                 Optional.empty(), Optional.empty(), now,
                 Optional.empty(), Optional.empty(), Optional.empty(),
                 0L, "", "",
-                Optional.empty(), Optional.empty(), List.of()
+                Optional.empty(), Optional.empty(), List.of(),
+                Optional.empty()
         );
         service.insert(bare);
         Optional<DBSong> foundBare = service.getSongById("song-bare");
@@ -671,7 +676,29 @@ public class DatabaseServerServiceTest {
         return new DBSong(id, serverId, albumId, albumName, title, Optional.empty(), artistId, artistName,
                 Duration.ofMinutes(3), Optional.empty(), Optional.empty(), now,
                 Optional.empty(), Optional.empty(), Optional.empty(), 1000L, "", "mp3",
-                Optional.empty(), Optional.empty(), List.of());
+                Optional.empty(), Optional.empty(), List.of(), Optional.empty());
+    }
+
+    @Test
+    public void testReplayGainPersistenceRoundTrip() throws Exception {
+        File dbFile = folder.newFile("test_replaygain.db");
+        Database db = new Database("jdbc:sqlite:" + dbFile.getAbsolutePath());
+        UUID serverId = UUID.randomUUID();
+        DatabaseServerService service = new DatabaseServerService(serverId, db);
+
+        // A song WITH ReplayGain metadata round-trips exactly.
+        var rg = new ServerClient.ReplayGain(-6.5, -4.0, 0.98, 1.02);
+        SongInfo withRg = downloadableSong("song-rg").withReplayGain(Optional.of(rg));
+        service.insert(DBSong.from(withRg, serverId));
+        DBSong loaded = service.getSongById("song-rg").orElseThrow();
+        Assertions.assertThat(loaded.replayGain()).contains(rg);
+
+        // A song WITHOUT ReplayGain metadata reads back as empty (also covers rows that
+        // predate the migration, whose gain columns are NULL).
+        SongInfo withoutRg = downloadableSong("song-plain");
+        Assertions.assertThat(withoutRg.replayGain()).isEmpty();
+        service.insert(DBSong.from(withoutRg, serverId));
+        Assertions.assertThat(service.getSongById("song-plain").orElseThrow().replayGain()).isEmpty();
     }
 
     private static SongInfo downloadableSong(String songId) {

--- a/src/test/java/org/subsound/persistence/database/DatabaseServiceTest.java
+++ b/src/test/java/org/subsound/persistence/database/DatabaseServiceTest.java
@@ -1,6 +1,7 @@
 package org.subsound.persistence.database;
 
 import org.subsound.integration.ServerClient.HttpHeader;
+import org.subsound.integration.ServerClient.ReplayGainConfig;
 import org.subsound.integration.ServerClient.ServerType;
 import org.assertj.core.api.Assertions;
 import org.junit.Rule;
@@ -40,7 +41,8 @@ public class DatabaseServiceTest {
                 List.of(
                         new HttpHeader("CF-Access-Client-Id", "abc123"),
                         new HttpHeader("CF-Access-Client-Secret", "s3cr3t")
-                )
+                ),
+                ReplayGainConfig.defaultConfig()
         );
 
         Server server2 = new Server(
@@ -53,7 +55,8 @@ public class DatabaseServiceTest {
                 false,
                 null,
                 null,
-                List.of()
+                List.of(),
+                ReplayGainConfig.defaultConfig()
         );
 
         // Test insert
@@ -93,7 +96,8 @@ public class DatabaseServiceTest {
         // upsert must preserve/replace custom headers
         Server server1Updated = new Server(
                 server1.id(), true, ServerType.SUBSONIC, "http://server1.com", "user1",
-                now, false, null, null, List.of(new HttpHeader("X-Custom", "v"))
+                now, false, null, null, List.of(new HttpHeader("X-Custom", "v")),
+                ReplayGainConfig.defaultConfig()
         );
         service.upsert(server1Updated);
         Assertions.assertThat(service.getServerById(server1.id().toString()))

--- a/src/test/java/org/subsound/persistence/database/DatabaseTest.java
+++ b/src/test/java/org/subsound/persistence/database/DatabaseTest.java
@@ -40,7 +40,7 @@ public class DatabaseTest {
             // Check version
             try (ResultSet rs = stmt.executeQuery("SELECT MAX(version) FROM schema_version")) {
                 Assertions.assertThat(rs.next()).isTrue();
-                Assertions.assertThat(rs.getInt(1)).isEqualTo(22);
+                Assertions.assertThat(rs.getInt(1)).isEqualTo(23);
             }
 
             // Check if lyrics table exists

--- a/src/test/java/org/subsound/persistence/database/PlayQueuePersistenceTest.java
+++ b/src/test/java/org/subsound/persistence/database/PlayQueuePersistenceTest.java
@@ -26,7 +26,8 @@ public class PlayQueuePersistenceTest {
                 Instant.now().truncatedTo(ChronoUnit.MILLIS),
                 Optional.of(1), Optional.of(1), Optional.of(320),
                 5000000L, "Rock", "mp3",
-                Optional.empty(), Optional.empty(), List.of()
+                Optional.empty(), Optional.empty(), List.of(),
+                Optional.empty()
         );
     }
 


### PR DESCRIPTION
OpenSubsonic `replayGain` metadata was already parsed in `SubsonicClientV2` but discarded. This threads it end-to-end and applies it at playback time.

## Data path
- `SongInfo` gains an `Optional<ReplayGain>` (track/album gain + peaks), mapped in `toSongInfo` and persisted to the `songs` table (`MigrationV23`). Modeled as `Optional` so missing / pre-migration metadata is a first-class case (old cached rows read back as absent).

## Settings (per-server)
- `ReplayGainConfig{enabled, mode TRACK/ALBUM, preAmpDb, fallbackGainDb}` stored as JSON on the `servers` table, mirroring the transcode-settings convention. Exposed via a new **ReplayGain** group in `SettingsPage` (switch / combo / two spin rows).

## Playback
- `AppManager.computeReplayGainScale` derives the linear multiplier (mode → gain, +pre-amp, configurable fallback, peak-based clip clamp) and pushes it to `PlaybinPlayer`.
- `PlaybinPlayer` applies it via a dedicated `volume` element attached as playbin's `audio-filter`, independent of the user volume. `setReplayGainScale` updates the current track live when settings change.

## Tests
- New `ReplayGainScaleTest` (disabled / track / album / fallback / pre-amp / peak-clamp) + DB round-trip.
