### PR TITLE
Add drag-and-drop of songs onto playlists in the overview

### DIFF
--- a/flatpak-sources.json
+++ b/flatpak-sources.json
@@ -1471,171 +1471,171 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/java-gi/adw/0.15.0/adw-0.15.0.jar",
-    "sha512": "c40c1f7653daffbe31338a0204213385acb0cd003095922db5144573d0d2a358bb6b19a583f95e637ec0040ac87a64e96db2a9b0e2b8f23c053b9101366b4f72",
-    "dest": "./offline-repository/org/java-gi/adw/0.15.0",
-    "dest-filename": "adw-0.15.0.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/java-gi/adw/1.0.0-RC3/adw-1.0.0-RC3.jar",
+    "sha512": "9f1c37fe009fea63d8bbc57a75448dfa39945bced15747751cfa1559d37d5f4c5d82f62e136801cd88960945b6fe7ac91323187ad9a3fd764163c7e2c1f8e29f",
+    "dest": "./offline-repository/org/java-gi/adw/1.0.0-RC3",
+    "dest-filename": "adw-1.0.0-RC3.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/java-gi/adw/0.15.0/adw-0.15.0.module",
-    "sha512": "653ef0b30b893ded121f485c56892a6a0d8f9ece98c9f2d2e4d79a62183d7f0f170569c0575d9e85de1962c771445a54c1ea206e9cd062d763fd6a58d6b57501",
-    "dest": "./offline-repository/org/java-gi/adw/0.15.0",
-    "dest-filename": "adw-0.15.0.module"
+    "url": "https://repo.maven.apache.org/maven2/org/java-gi/adw/1.0.0-RC3/adw-1.0.0-RC3.module",
+    "sha512": "f9b0b21936e7b453b805f5807223c041cef3e2eb5917bb38047302b7e5ca372b72df2b11cbc3e76f1947aa4e4b65826bc1d37bf68884a3348bcb97b31e01cbd1",
+    "dest": "./offline-repository/org/java-gi/adw/1.0.0-RC3",
+    "dest-filename": "adw-1.0.0-RC3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/java-gi/adw/0.15.0/adw-0.15.0.pom",
-    "sha512": "d90fb2e8f7f3173cc43ac877d974947d83b091473f4fb01426b0d6a78307bf52771be3285f5e410cd0f25f55ea3b85b61c2fec32bd2fe6094e009381604f2956",
-    "dest": "./offline-repository/org/java-gi/adw/0.15.0",
-    "dest-filename": "adw-0.15.0.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/java-gi/adw/1.0.0-RC3/adw-1.0.0-RC3.pom",
+    "sha512": "961e796659cac5bd6cfe44f0acafa51cb90ea5676234195251bfc8a29d0b4c3c7fd07730df34ee5f443f9e2ff3dd5a9295f6cc49ff4569bead440738283f764f",
+    "dest": "./offline-repository/org/java-gi/adw/1.0.0-RC3",
+    "dest-filename": "adw-1.0.0-RC3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/java-gi/gdkpixbuf/0.15.0/gdkpixbuf-0.15.0.jar",
-    "sha512": "f7086ddef4af770fe845afdef3e7441ce42c2541f448690f78e7b135bd4ceaa7aba38cb317a446c8313c67200b919533577808078a86eb4233064b7a387fb7de",
-    "dest": "./offline-repository/org/java-gi/gdkpixbuf/0.15.0",
-    "dest-filename": "gdkpixbuf-0.15.0.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/java-gi/gdkpixbuf/1.0.0-RC3/gdkpixbuf-1.0.0-RC3.jar",
+    "sha512": "c08ff2647dc8566938b5c4357b5ab124c78c1214fc3ca77aac2785b957a3a41e16227d52ff0bd5cd6927d8166e6541b0dade22092f44024342925e8fc5a629e5",
+    "dest": "./offline-repository/org/java-gi/gdkpixbuf/1.0.0-RC3",
+    "dest-filename": "gdkpixbuf-1.0.0-RC3.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/java-gi/gdkpixbuf/0.15.0/gdkpixbuf-0.15.0.module",
-    "sha512": "991d7e546be54c2e06be94c12401f4c5e02386d506057a3e6939fefec7a1a4b5968eb16d0a9d733ac410a6dc340f9030c37fd4d829558b49b7b50569ca0ea412",
-    "dest": "./offline-repository/org/java-gi/gdkpixbuf/0.15.0",
-    "dest-filename": "gdkpixbuf-0.15.0.module"
+    "url": "https://repo.maven.apache.org/maven2/org/java-gi/gdkpixbuf/1.0.0-RC3/gdkpixbuf-1.0.0-RC3.module",
+    "sha512": "7e8d7b57e15d71a217cd7cb77840f4a3a73d16d9a660e77035421fde8de03740cb376b03b13d9dd62f66701aec9166b6ea645be51b473f79a96cfa834254df84",
+    "dest": "./offline-repository/org/java-gi/gdkpixbuf/1.0.0-RC3",
+    "dest-filename": "gdkpixbuf-1.0.0-RC3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/java-gi/gdkpixbuf/0.15.0/gdkpixbuf-0.15.0.pom",
-    "sha512": "edf7e052901d390530788fd0c45b7ffe3f7de34a1c9e016f65c94db38bc6d2aac317556fca193795dcd5179c8b7514bf3c42a29f29729821c166af805c6f4b2d",
-    "dest": "./offline-repository/org/java-gi/gdkpixbuf/0.15.0",
-    "dest-filename": "gdkpixbuf-0.15.0.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/java-gi/gdkpixbuf/1.0.0-RC3/gdkpixbuf-1.0.0-RC3.pom",
+    "sha512": "57c8ce13e5fb1fb39f5aa3503d5475c906b839db2386518d2f84978c1584c6612d78b972cd0a27dad113c67deec11d041efe74e1ad3f5394e4e3de29b21052ea",
+    "dest": "./offline-repository/org/java-gi/gdkpixbuf/1.0.0-RC3",
+    "dest-filename": "gdkpixbuf-1.0.0-RC3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/java-gi/glib/0.15.0/glib-0.15.0.jar",
-    "sha512": "f1b5b692a7861b0c8f01b63689180d1cd023d6b82b8e9e49282b2c61b2dca4a7d2cccc09a841635eaa196025c60801f4c0c4757124f5fabfbe63b7128afa36ca",
-    "dest": "./offline-repository/org/java-gi/glib/0.15.0",
-    "dest-filename": "glib-0.15.0.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/java-gi/glib/1.0.0-RC3/glib-1.0.0-RC3.jar",
+    "sha512": "1cc992815210be775822378e55236c743bfc229e50881cd854a4841ca8d6d46afe94d6c0eb892211b7f37722b8b188c59b12f1170490a91888f3cba10fefb1c5",
+    "dest": "./offline-repository/org/java-gi/glib/1.0.0-RC3",
+    "dest-filename": "glib-1.0.0-RC3.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/java-gi/glib/0.15.0/glib-0.15.0.module",
-    "sha512": "a64e4a0daf1410a1ae0995a8d918af1dcfbb98564b5a59229d5b410a64295ff385fa0bd463a1af966aa776ec047a186d5d3c8aa1baaaf33996d1434c8d0bf106",
-    "dest": "./offline-repository/org/java-gi/glib/0.15.0",
-    "dest-filename": "glib-0.15.0.module"
+    "url": "https://repo.maven.apache.org/maven2/org/java-gi/glib/1.0.0-RC3/glib-1.0.0-RC3.module",
+    "sha512": "451fa3655ed7c9cbb435da8d08321407a1db005b0bf9c5d23f2ba7c09fc2a3fe473ce4f63724eeae5d5c80d7997cea87267975f5624a5e7adc27003b89e6b99d",
+    "dest": "./offline-repository/org/java-gi/glib/1.0.0-RC3",
+    "dest-filename": "glib-1.0.0-RC3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/java-gi/glib/0.15.0/glib-0.15.0.pom",
-    "sha512": "41d235baeaaadd136f68685f5b54680844860ac9465a7a973fff45bdce765a6ec7c750c2a6349a1b72f32be86946806c5deab8ff9770434a87236ef95b25504b",
-    "dest": "./offline-repository/org/java-gi/glib/0.15.0",
-    "dest-filename": "glib-0.15.0.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/java-gi/glib/1.0.0-RC3/glib-1.0.0-RC3.pom",
+    "sha512": "a0ebaea33905ef09c22f79072d173ebfa5573489e03b0634c32c7747069a278d23f5f477a34e5ae732a1f4d3f6b0376895d5f6aa13267fec7ff3e18d3e852f65",
+    "dest": "./offline-repository/org/java-gi/glib/1.0.0-RC3",
+    "dest-filename": "glib-1.0.0-RC3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/java-gi/gstreamer/0.15.0/gstreamer-0.15.0.jar",
-    "sha512": "c347bc76efbff4eaed2d78d1c30d9bcb37f19ef147b813ca2d004679b808e0f1e461fe505188badab762453aa1156863d986beb0cdc20d4919e035294a2d210b",
-    "dest": "./offline-repository/org/java-gi/gstreamer/0.15.0",
-    "dest-filename": "gstreamer-0.15.0.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/java-gi/gstreamer/1.0.0-RC3/gstreamer-1.0.0-RC3.jar",
+    "sha512": "a785da4d2e7dce40fe8579af6f7fd9cc2df01836c87749efe68d71345b7d49faff90786ba673b75a04f3936a011754cbc4d4b6ee4da4225a90232391852ac8dd",
+    "dest": "./offline-repository/org/java-gi/gstreamer/1.0.0-RC3",
+    "dest-filename": "gstreamer-1.0.0-RC3.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/java-gi/gstreamer/0.15.0/gstreamer-0.15.0.module",
-    "sha512": "8a9fda1568460212a6a45ed04d1e270b6a94c4fc65eeca4c5db88f53c010f483b946d4d53f9402269efcfe9d12e7bb60fd23c9d71a2551c4a960c3f1064187ce",
-    "dest": "./offline-repository/org/java-gi/gstreamer/0.15.0",
-    "dest-filename": "gstreamer-0.15.0.module"
+    "url": "https://repo.maven.apache.org/maven2/org/java-gi/gstreamer/1.0.0-RC3/gstreamer-1.0.0-RC3.module",
+    "sha512": "9806405856ad787571cc07a74fc7887671353fd8506f962a6fa46d554c809598f6f564a0ed75000b571f80fd5cee1e1938d2880070f2322d692bc09d8fd4b6b6",
+    "dest": "./offline-repository/org/java-gi/gstreamer/1.0.0-RC3",
+    "dest-filename": "gstreamer-1.0.0-RC3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/java-gi/gstreamer/0.15.0/gstreamer-0.15.0.pom",
-    "sha512": "6d65b01d810ebd13c51d9bba525b08348001087b3e8a6b1fdda38730140b2aca7b4bb99e03b489c934b4b94ef2215731487168f15f8f219a1f4fc8631ce87845",
-    "dest": "./offline-repository/org/java-gi/gstreamer/0.15.0",
-    "dest-filename": "gstreamer-0.15.0.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/java-gi/gstreamer/1.0.0-RC3/gstreamer-1.0.0-RC3.pom",
+    "sha512": "6f5c3b3123f1217dd4cdd41038ecbb270a6fbfd831f3114156b732c77f5e64124b3325647e5c95578582e48d66371936b9ae1a14f65bc75f32e22294b22cc8f5",
+    "dest": "./offline-repository/org/java-gi/gstreamer/1.0.0-RC3",
+    "dest-filename": "gstreamer-1.0.0-RC3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/java-gi/gtk/0.15.0/gtk-0.15.0.jar",
-    "sha512": "26e5838e8233b3baf51a8e875edf6126a57175928c5d49580fe45cc2a04d7ca6a7427f7e22ed42a3f3a19a41c951485abd595eaf8bde78c403796b14a9fb9c76",
-    "dest": "./offline-repository/org/java-gi/gtk/0.15.0",
-    "dest-filename": "gtk-0.15.0.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/java-gi/gtk/1.0.0-RC3/gtk-1.0.0-RC3.jar",
+    "sha512": "39166f6e66ecb2c1efe4fc93b55a205bab59f3c358f0a04b6137b3fe647ff37be24809be15520c3bbc4cc0233b2a6973248979f46f1af4f2db1fc14844e61043",
+    "dest": "./offline-repository/org/java-gi/gtk/1.0.0-RC3",
+    "dest-filename": "gtk-1.0.0-RC3.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/java-gi/gtk/0.15.0/gtk-0.15.0.module",
-    "sha512": "48a6e3d07e516e940281afa64b66ae5e9bc4044573f1bbae99d6899614cc32f4a49eb827ca69a4bbf077e26a726a33f27ef20813eafbd589bd9b0df4b160f2c6",
-    "dest": "./offline-repository/org/java-gi/gtk/0.15.0",
-    "dest-filename": "gtk-0.15.0.module"
+    "url": "https://repo.maven.apache.org/maven2/org/java-gi/gtk/1.0.0-RC3/gtk-1.0.0-RC3.module",
+    "sha512": "6f5f1afdee72968867ff61234e179ce2f0bd40848a72c1ce7db39148bbf18f9bfa2c8b0532938ece3bc7f49cf70dc9fb82854359613baffb7ad05d5af23ca07b",
+    "dest": "./offline-repository/org/java-gi/gtk/1.0.0-RC3",
+    "dest-filename": "gtk-1.0.0-RC3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/java-gi/gtk/0.15.0/gtk-0.15.0.pom",
-    "sha512": "791932cd27ad7603f40633a8f65a49ee01ca4a0b6481cf942a3775c9bb7d71b4f8bce0def5e17e896fc3fa3de15c5d3d4734a2870624042e08f1488229c394af",
-    "dest": "./offline-repository/org/java-gi/gtk/0.15.0",
-    "dest-filename": "gtk-0.15.0.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/java-gi/gtk/1.0.0-RC3/gtk-1.0.0-RC3.pom",
+    "sha512": "03b7914499e953f6a8a388378573060f9f9bab1dd8d90631309b8bebb65fb500f6ce907919de74953055fa49289cb1a780587e08b6da9840e5cb666d5d4c16be",
+    "dest": "./offline-repository/org/java-gi/gtk/1.0.0-RC3",
+    "dest-filename": "gtk-1.0.0-RC3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/java-gi/harfbuzz/0.15.0/harfbuzz-0.15.0.jar",
-    "sha512": "c848f0a7c265c61e97926754bafc522cc9a4e410c7a8b1cccb6efc03ec61d52f78582636fd71a4db17273def6e6c624a7ed88598204f2950791bf37e45fef13e",
-    "dest": "./offline-repository/org/java-gi/harfbuzz/0.15.0",
-    "dest-filename": "harfbuzz-0.15.0.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/java-gi/harfbuzz/1.0.0-RC3/harfbuzz-1.0.0-RC3.jar",
+    "sha512": "96438debda4527e407d95b173204beaac6db0fe231dc5d845ca4591d7fe6f79285258330532963d4d64ea3dc443ff9a7d845a022bef1e8ed4e06688e0b7d8982",
+    "dest": "./offline-repository/org/java-gi/harfbuzz/1.0.0-RC3",
+    "dest-filename": "harfbuzz-1.0.0-RC3.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/java-gi/harfbuzz/0.15.0/harfbuzz-0.15.0.module",
-    "sha512": "e8952d594b764415d6189f77907bea52c558349b6e162e5d92c378920adbd47ac95ed888c58b4b599a726cb6c993d396ca0027d92402b2a3a07b927ea509794e",
-    "dest": "./offline-repository/org/java-gi/harfbuzz/0.15.0",
-    "dest-filename": "harfbuzz-0.15.0.module"
+    "url": "https://repo.maven.apache.org/maven2/org/java-gi/harfbuzz/1.0.0-RC3/harfbuzz-1.0.0-RC3.module",
+    "sha512": "478c24973befaf3f85ad1e1cbc9eb83b5bcbc3f710009f299267f268c12f32ddf1fd01919eb0e5604e4f1848b6c389eb77471191d19e8cc389f4f327d7a5abcb",
+    "dest": "./offline-repository/org/java-gi/harfbuzz/1.0.0-RC3",
+    "dest-filename": "harfbuzz-1.0.0-RC3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/java-gi/harfbuzz/0.15.0/harfbuzz-0.15.0.pom",
-    "sha512": "b82d08f70189861fc794960441430e85f5be0be05a703db38ef87521a4d30daecc79cad3b809eb2cf139166a90d1d96f7f0c0d5c6532317dd685f7cd08566e60",
-    "dest": "./offline-repository/org/java-gi/harfbuzz/0.15.0",
-    "dest-filename": "harfbuzz-0.15.0.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/java-gi/harfbuzz/1.0.0-RC3/harfbuzz-1.0.0-RC3.pom",
+    "sha512": "d485e5835f13407215a879bcdab803d968f7f1124743465a7f9430d9ee245197cf4eb0f3e421ab82eec190c35f899597929bc29c50187d9972b318e5ee0e90d7",
+    "dest": "./offline-repository/org/java-gi/harfbuzz/1.0.0-RC3",
+    "dest-filename": "harfbuzz-1.0.0-RC3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/java-gi/pango/0.15.0/pango-0.15.0.jar",
-    "sha512": "2fe20c11e8519fde170a54498a4631c61bce3da5a25e1d9eafd6997fe13d96e1d41ff0c0650f63748b613e76d736f84fc7becf7cb6432e069f51aa766c2fb1d5",
-    "dest": "./offline-repository/org/java-gi/pango/0.15.0",
-    "dest-filename": "pango-0.15.0.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/java-gi/pango/1.0.0-RC3/pango-1.0.0-RC3.jar",
+    "sha512": "6f05cf7e56fb28a82257bed6e981b0e4de6c5165facdb1f88b67cf19e5e46c47cd22ee740ecaa92e6feb7f35c9eb7b1cc04471e5586b42765a5fa36618c5d5d7",
+    "dest": "./offline-repository/org/java-gi/pango/1.0.0-RC3",
+    "dest-filename": "pango-1.0.0-RC3.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/java-gi/pango/0.15.0/pango-0.15.0.module",
-    "sha512": "69de84994c25d63d3e35730d6e3ce7d3de26849a005fb9d973837641250cfaa2dbebfb0ce1c54517fa16eb6a64d18e58f79ad30863a2ffd8b7d1af936b8cad80",
-    "dest": "./offline-repository/org/java-gi/pango/0.15.0",
-    "dest-filename": "pango-0.15.0.module"
+    "url": "https://repo.maven.apache.org/maven2/org/java-gi/pango/1.0.0-RC3/pango-1.0.0-RC3.module",
+    "sha512": "f75ccbb5a5aaee4110e8fec4cf01903fbd7e4b42ab5327f112734886e839644277037d2d0abfca6aa97610622b727ceeb633096b46dd08f2bc51fd74a7c82e0b",
+    "dest": "./offline-repository/org/java-gi/pango/1.0.0-RC3",
+    "dest-filename": "pango-1.0.0-RC3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/java-gi/pango/0.15.0/pango-0.15.0.pom",
-    "sha512": "48fce9008c0b12be5a7a55f2b50b6341473ad6831b166bdbc54628c412c101140580d514f9b0287abebb20f4ac0a6f92d1f908c21dddcfb52d79f7fbbb53f5ab",
-    "dest": "./offline-repository/org/java-gi/pango/0.15.0",
-    "dest-filename": "pango-0.15.0.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/java-gi/pango/1.0.0-RC3/pango-1.0.0-RC3.pom",
+    "sha512": "db04bbf76e3e3edf7cc35a8415130b436407ca3354f9652f91e3f2d579dbb574ceb02081b2db40bc4f77e802cc0ff58f336b6c58660c28713f45db691f335b9c",
+    "dest": "./offline-repository/org/java-gi/pango/1.0.0-RC3",
+    "dest-filename": "pango-1.0.0-RC3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/java-gi/secret/0.15.0/secret-0.15.0.jar",
-    "sha512": "cd6ae7664f0cfb2499dc9d6b0c02e47d23cf4d428881292bd04445c16c71061de817487eb6400b9454db28ebd0e7ecc4a3a59bfd9ac71ebb2ac5c7662b6b1654",
-    "dest": "./offline-repository/org/java-gi/secret/0.15.0",
-    "dest-filename": "secret-0.15.0.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/java-gi/secret/1.0.0-RC3/secret-1.0.0-RC3.jar",
+    "sha512": "f51a56e5b83ff1e71c61b7eca0668da4744eb1135dafc8ae6e6df96aa8356ac59f9f888d6177d9510ed20f4226a7198c0c5479256d11b68019f632e94f4358b5",
+    "dest": "./offline-repository/org/java-gi/secret/1.0.0-RC3",
+    "dest-filename": "secret-1.0.0-RC3.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/java-gi/secret/0.15.0/secret-0.15.0.module",
-    "sha512": "a78c61352ed976118533601bee74a3a65458b95417797edbdc98382c3bbfaa1aad2bce867867b89839a11ac301612c42b32c9c5dfc72eb5fe0aa2e64622fd8af",
-    "dest": "./offline-repository/org/java-gi/secret/0.15.0",
-    "dest-filename": "secret-0.15.0.module"
+    "url": "https://repo.maven.apache.org/maven2/org/java-gi/secret/1.0.0-RC3/secret-1.0.0-RC3.module",
+    "sha512": "96b4a8f701e0aa1ae63880d8bfa8be1bbd54eaae58ed8a085291c35dafeee1edbefdba813065a9f43042293bb50816efe88a7fca40c479a86a9444a654596c94",
+    "dest": "./offline-repository/org/java-gi/secret/1.0.0-RC3",
+    "dest-filename": "secret-1.0.0-RC3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/java-gi/secret/0.15.0/secret-0.15.0.pom",
-    "sha512": "b15d4644eabe492e711bc552c1fecf72ac375150f3a0f7a3a1800c728dd8ef494b03f55aa11dc475c0c0b5b97684a865aa132a76c15d103edb74cfa14d567c5b",
-    "dest": "./offline-repository/org/java-gi/secret/0.15.0",
-    "dest-filename": "secret-0.15.0.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/java-gi/secret/1.0.0-RC3/secret-1.0.0-RC3.pom",
+    "sha512": "aa9eb44eecb916345de7d98beb6b89808208d2b742f6e7e2dc6f97bcaf37bb37ab0484d068f0671a1c8ddb9138db47d3446a0bb632d409d1cdc71b42d68ba432",
+    "dest": "./offline-repository/org/java-gi/secret/1.0.0-RC3",
+    "dest-filename": "secret-1.0.0-RC3.pom"
   },
   {
     "type": "file",
@@ -1779,24 +1779,24 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar",
-    "sha512": "efded31ef5b342f09422935076e599789076431e93a746685c0607e7de5592719ba6aacde0be670b3f064d1e85630d58d5bce6b34aed2a288fdb34f745efb7bc",
-    "dest": "./offline-repository/org/jspecify/jspecify/1.0.0",
-    "dest-filename": "jspecify-1.0.0.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jspecify/jspecify/1.0.1/jspecify-1.0.1.jar",
+    "sha512": "8f5ca6f5c25ee353bfbe3e5e5cd9847b3b3ed1e954a14a52c9aa016c673e02bfbc2e0f9308ad576c2a58720f8bf2139ad9883c7a881050fe96a2f87e2e623711",
+    "dest": "./offline-repository/org/jspecify/jspecify/1.0.1",
+    "dest-filename": "jspecify-1.0.1.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jspecify/jspecify/1.0.0/jspecify-1.0.0.module",
-    "sha512": "02669b1c62e0c6988dd812b89201acbe6dad796f3573d6e626d2f56d2194896e198bf3998f0618019b722c7b0c93f013528bff1118f835154f2bd61c17e67b77",
-    "dest": "./offline-repository/org/jspecify/jspecify/1.0.0",
-    "dest-filename": "jspecify-1.0.0.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jspecify/jspecify/1.0.1/jspecify-1.0.1.module",
+    "sha512": "eee956daa01d8e6e5056cfa3f1e739d22da7d527b6415af1e2ec1ccab935f89492981845a79a0b1c364ecdc6d8cc6221b4340dc2fa40092403d6966a8bfa81c1",
+    "dest": "./offline-repository/org/jspecify/jspecify/1.0.1",
+    "dest-filename": "jspecify-1.0.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jspecify/jspecify/1.0.0/jspecify-1.0.0.pom",
-    "sha512": "291d8fb333121ba18ebd427e7ee5e98694be797b8280a228be7c4958af934b2465f341957248dcd396f5ffbe99dd9a65aa61cef70ca772ee37a92c3d20e41f32",
-    "dest": "./offline-repository/org/jspecify/jspecify/1.0.0",
-    "dest-filename": "jspecify-1.0.0.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jspecify/jspecify/1.0.1/jspecify-1.0.1.pom",
+    "sha512": "fea076d1071a5057ac38bd3fb8e5b5483ee646180d1995f43e154ed7918eaf4299d5752759b9d2f40cb5c1ca00e83b590200a173a33d1fd6c51da48521c3d24a",
+    "dest": "./offline-repository/org/jspecify/jspecify/1.0.1",
+    "dest-filename": "jspecify-1.0.1.pom"
   },
   {
     "type": "file",

--- a/po/io.github.subsoundorg.Subsound.pot
+++ b/po/io.github.subsoundorg.Subsound.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Subsound\n"
 "Report-Msgid-Bugs-To: https://github.com/subsoundorg/subsound-gtk/issues\n"
-"POT-Creation-Date: 2026-07-31 17:54+0200\n"
+"POT-Creation-Date: 2026-08-07 01:06+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
 #: src/main/java/org/subsound/MainApplication.java:169
-#: src/main/java/org/subsound/MainApplication.java:302
+#: src/main/java/org/subsound/MainApplication.java:303
 #, java-printf-format
 msgid "Settings"
 msgstr ""
@@ -35,36 +35,36 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: src/main/java/org/subsound/MainApplication.java:310
+#: src/main/java/org/subsound/MainApplication.java:311
 #: src/main/java/org/subsound/ui/components/CommandPalette.java:297
 #: src/main/java/org/subsound/ui/components/CommandPalette.java:328
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:191
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:467
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:194
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:516
 #, java-printf-format
 msgid "Album"
 msgstr ""
 
-#: src/main/java/org/subsound/MainApplication.java:330
+#: src/main/java/org/subsound/MainApplication.java:331
 #: src/main/java/org/subsound/ui/components/LyricsPopover.java:46
 #: src/main/java/org/subsound/ui/components/PlayerBar.java:280
 #, java-printf-format
 msgid "Lyrics"
 msgstr ""
 
-#: src/main/java/org/subsound/MainApplication.java:357
+#: src/main/java/org/subsound/MainApplication.java:358
 #: src/main/java/org/subsound/ui/views/FrontpagePage.java:142
 #, java-printf-format
 msgid "Home"
 msgstr ""
 
-#: src/main/java/org/subsound/MainApplication.java:363
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:303
+#: src/main/java/org/subsound/MainApplication.java:364
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:329
 #: src/main/java/org/subsound/ui/views/FrontpagePage.java:244
 #, java-printf-format
 msgid "Playlists"
 msgstr ""
 
-#: src/main/java/org/subsound/MainApplication.java:373
+#: src/main/java/org/subsound/MainApplication.java:374
 #: src/main/java/org/subsound/ui/views/ArtistsListView.java:151
 #, java-printf-format
 msgid "Artists"
@@ -150,8 +150,8 @@ msgid "Failed to start server: %s"
 msgstr ""
 
 #: src/main/java/org/subsound/app/state/PlaylistsStore.java:150
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:127
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:361
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:134
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:425
 #, java-printf-format
 msgid "Starred"
 msgstr ""
@@ -261,56 +261,57 @@ msgstr ""
 msgid "Add all to playlist:"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:133
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:140
 #, java-printf-format
 msgid "Select a playlist to view"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:271
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:252
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:297
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:255
 #, java-printf-format
 msgid "Library"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:279
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:305
 #, java-printf-format
 msgid "New playlist"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:515
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1521
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:579
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1588
 #, java-printf-format
 msgid "Playlist name"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:520
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:584
 #, java-printf-format
 msgid "Create Playlist"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:521
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:585
 #, java-printf-format
 msgid "Enter a name for the new playlist"
 msgstr ""
 
 #. TRANSLATORS: "_" marks the mnemonic key
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:524
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:588
 #: src/main/java/org/subsound/ui/components/ServerBadge.java:168
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1531
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1575
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1598
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1642
 #, java-printf-format
 msgid "_Cancel"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:525
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:589
 #, java-printf-format
 msgid "_Create"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:684
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:688
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:691
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:696
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:748
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:752
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:755
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:760
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:393
 #, java-printf-format
 msgid "%d item"
 msgid_plural "%d items"
@@ -496,211 +497,211 @@ msgstr ""
 msgid "Configuration saved!"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:84
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:85
 #, java-printf-format
 msgid "Clear song cache"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:88
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:89
 #, java-printf-format
 msgid "Clear thumbnail cache"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:92
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:93
 #, java-printf-format
 msgid "Clear lyrics cache"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:97
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:98
 #, java-printf-format
 msgid "Local Settings"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:107
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:131
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:108
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:132
 #, java-printf-format
 msgid "Source"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:124
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:125
 #, java-printf-format
 msgid "Audio format"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:135
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:136
 #, java-printf-format
 msgid "Max bitrate"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:161
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:162
 #, java-printf-format
 msgid "Server information"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:163
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:164
 #, java-printf-format
 msgid "Type"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:164
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:165
 #, java-printf-format
 msgid "Version"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:165
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:166
 #, java-printf-format
 msgid "API Version"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:166
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:167
 #, java-printf-format
 msgid "OpenSubsonic support"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:171
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:172
 #, java-printf-format
 msgid "OpenSubsonic extensions"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:176
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:177
 #, java-printf-format
 msgid "Transcode Settings"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:184
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:187
 #, java-printf-format
 msgid "Enable ReplayGain"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:185
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:188
 #, java-printf-format
 msgid "Normalize playback loudness across tracks"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:190
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:193
 #, java-printf-format
 msgid "Track"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:193
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:196
 #, java-printf-format
 msgid "Normalization mode"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:194
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:197
 #, java-printf-format
 msgid "Album mode preserves an album's internal dynamics"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:199
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:202
 #, java-printf-format
 msgid "Pre-amp (dB)"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:204
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:207
 #, java-printf-format
 msgid "Fallback gain (dB)"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:205
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:208
 #, java-printf-format
 msgid "Applied to tracks without ReplayGain data"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:210
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:213
 #, java-printf-format
 msgid "ReplayGain"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:228
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:231
 #, java-printf-format
 msgid "Full scan"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:230
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:233
 #, java-printf-format
 msgid "Start server scan for new songs and folders"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:238
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:241
 #, java-printf-format
 msgid "Quick scan"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:240
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:243
 #, java-printf-format
 msgid "Start server quick scan for new songs and folders"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:247
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:250
 #, java-printf-format
 msgid "Last Scanned at"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:248
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:251
 #, java-printf-format
 msgid "Status"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:249
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:252
 #, java-printf-format
 msgid "Server songs"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:259
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:262
 #, java-printf-format
 msgid "Local songs"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:263
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:266
 #, java-printf-format
 msgid "Sync library"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:265
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:268
 #, java-printf-format
 msgid "Syncs metadata for offline use"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:280
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:283
 #, java-printf-format
 msgid "Local Library"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:359
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:360
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:362
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:363
 #, java-printf-format
 msgid "Unknown"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:362
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:365
 #, java-printf-format
 msgid "No"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:362
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:365
 #, java-printf-format
 msgid "Yes"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/components/SongContextMenu.java:68
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:417
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1334
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1657
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1401
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1724
 #, java-printf-format
 msgid "Play"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/components/SongContextMenu.java:74
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:438
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1680
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1747
 #, java-printf-format
 msgid "Play Next"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/components/SongContextMenu.java:80
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:444
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1686
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1753
 #, java-printf-format
 msgid "Add to Queue"
 msgstr ""
@@ -713,22 +714,22 @@ msgstr ""
 #: src/main/java/org/subsound/ui/components/SongContextMenu.java:101
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:459
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:673
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1338
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1692
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1405
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1759
 #, java-printf-format
 msgid "Add to Playlist…"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/components/SongContextMenu.java:112
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:464
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1340
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1695
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1407
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1762
 #, java-printf-format
 msgid "Download"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/components/SongDownloadStatusIcon.java:44
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1423
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1490
 #, java-printf-format
 msgid "Available offline"
 msgstr ""
@@ -765,13 +766,13 @@ msgid "Add to Starred"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:450
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1344
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1411
 #, java-printf-format
 msgid "Unstar"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:490
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1736
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1803
 #, java-printf-format
 msgid "← Back"
 msgstr ""
@@ -784,7 +785,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:658
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1387
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1454
 #, java-printf-format
 msgid "Download all"
 msgstr ""
@@ -858,146 +859,146 @@ msgstr[1] ""
 msgid "Scanned %s ago"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:263
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:275
 #, java-printf-format
 msgid "Filter by title, artist, or album"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:389
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:911
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:438
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:978
 #, java-printf-format
 msgid "Title"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:498
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:547
 #, java-printf-format
 msgid "Duration"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:680
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:729
 #, java-printf-format
 msgid "Refresh playlist"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1320
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1387
 #, java-printf-format
 msgid "Clear selection"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1336
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1403
 #, java-printf-format
 msgid "Add to queue"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1342
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1409
 #, java-printf-format
 msgid "Star"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1346
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1374
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1708
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1413
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1441
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1775
 #, java-printf-format
 msgid "Remove from Playlist"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1369
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1436
 #, java-printf-format
 msgid "%d selected"
 msgid_plural "%d selected"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1373
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1717
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1440
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1784
 #, java-printf-format
 msgid "Remove from Downloads"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1386
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1453
 #, java-printf-format
 msgid "Rename…"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1388
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1455
 #, java-printf-format
 msgid "Delete Playlist…"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1527
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1594
 #, java-printf-format
 msgid "Rename Playlist"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1528
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1595
 #, java-printf-format
 msgid "Enter a new name for \"%s\""
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1532
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1599
 #, java-printf-format
 msgid "_Rename"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1571
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1638
 #, java-printf-format
 msgid "Delete Playlist"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1572
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1639
 #, java-printf-format
 msgid "Delete \"%s\"? This cannot be undone."
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1576
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1643
 #, java-printf-format
 msgid "_Delete"
 msgstr ""
 
-#: src/main/java/org/subsound/utils/Utils.java:182
-#: src/main/java/org/subsound/utils/Utils.java:206
+#: src/main/java/org/subsound/utils/Utils.java:190
+#: src/main/java/org/subsound/utils/Utils.java:214
 #, java-printf-format
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/main/java/org/subsound/utils/Utils.java:185
+#: src/main/java/org/subsound/utils/Utils.java:193
 #, java-printf-format
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/main/java/org/subsound/utils/Utils.java:188
+#: src/main/java/org/subsound/utils/Utils.java:196
 #, java-printf-format
 msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/main/java/org/subsound/utils/Utils.java:191
+#: src/main/java/org/subsound/utils/Utils.java:199
 #, java-printf-format
 msgid "%d second"
 msgid_plural "%d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/main/java/org/subsound/utils/Utils.java:211
+#: src/main/java/org/subsound/utils/Utils.java:219
 #, java-printf-format
 msgid "%d hr"
 msgid_plural "%d hr"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/main/java/org/subsound/utils/Utils.java:214
+#: src/main/java/org/subsound/utils/Utils.java:222
 #, java-printf-format
 msgid "%d min"
 msgid_plural "%d min"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/main/java/org/subsound/utils/Utils.java:217
+#: src/main/java/org/subsound/utils/Utils.java:225
 #, java-printf-format
 msgid "%d sec"
 msgid_plural "%d sec"

--- a/po/nb.po
+++ b/po/nb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Subsound\n"
 "Report-Msgid-Bugs-To: https://github.com/subsoundorg/subsound-gtk/issues\n"
-"POT-Creation-Date: 2026-07-31 17:54+0200\n"
+"POT-Creation-Date: 2026-08-07 01:06+0200\n"
 "PO-Revision-Date: 2026-07-11 00:16+0200\n"
 "Last-Translator: Eivind Siqveland Larsen <to.eivind@gmail.com>\n"
 "Language-Team: none\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: src/main/java/org/subsound/MainApplication.java:169
-#: src/main/java/org/subsound/MainApplication.java:302
+#: src/main/java/org/subsound/MainApplication.java:303
 #, java-printf-format
 msgid "Settings"
 msgstr "Innstillinger"
@@ -34,36 +34,36 @@ msgstr "Tilbake"
 msgid "Search"
 msgstr "Søk"
 
-#: src/main/java/org/subsound/MainApplication.java:310
+#: src/main/java/org/subsound/MainApplication.java:311
 #: src/main/java/org/subsound/ui/components/CommandPalette.java:297
 #: src/main/java/org/subsound/ui/components/CommandPalette.java:328
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:191
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:467
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:194
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:516
 #, java-printf-format
 msgid "Album"
 msgstr "Album"
 
-#: src/main/java/org/subsound/MainApplication.java:330
+#: src/main/java/org/subsound/MainApplication.java:331
 #: src/main/java/org/subsound/ui/components/LyricsPopover.java:46
 #: src/main/java/org/subsound/ui/components/PlayerBar.java:280
 #, java-printf-format
 msgid "Lyrics"
 msgstr ""
 
-#: src/main/java/org/subsound/MainApplication.java:357
+#: src/main/java/org/subsound/MainApplication.java:358
 #: src/main/java/org/subsound/ui/views/FrontpagePage.java:142
 #, java-printf-format
 msgid "Home"
 msgstr "Hjem"
 
-#: src/main/java/org/subsound/MainApplication.java:363
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:303
+#: src/main/java/org/subsound/MainApplication.java:364
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:329
 #: src/main/java/org/subsound/ui/views/FrontpagePage.java:244
 #, java-printf-format
 msgid "Playlists"
 msgstr "Spillelister"
 
-#: src/main/java/org/subsound/MainApplication.java:373
+#: src/main/java/org/subsound/MainApplication.java:374
 #: src/main/java/org/subsound/ui/views/ArtistsListView.java:151
 #, java-printf-format
 msgid "Artists"
@@ -149,8 +149,8 @@ msgid "Failed to start server: %s"
 msgstr ""
 
 #: src/main/java/org/subsound/app/state/PlaylistsStore.java:150
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:127
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:361
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:134
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:425
 #, java-printf-format
 msgid "Starred"
 msgstr "Favoritter"
@@ -260,56 +260,57 @@ msgstr "Gjenta sang"
 msgid "Add all to playlist:"
 msgstr "Legg alle til spillelisten:"
 
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:133
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:140
 #, java-printf-format
 msgid "Select a playlist to view"
 msgstr "Velg en spilleliste for å vise"
 
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:271
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:252
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:297
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:255
 #, java-printf-format
 msgid "Library"
 msgstr "Bibliotek"
 
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:279
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:305
 #, java-printf-format
 msgid "New playlist"
 msgstr "Ny spilleliste"
 
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:515
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1521
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:579
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1588
 #, java-printf-format
 msgid "Playlist name"
 msgstr "Spillelistenavn"
 
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:520
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:584
 #, java-printf-format
 msgid "Create Playlist"
 msgstr "Opprett spilleliste"
 
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:521
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:585
 #, java-printf-format
 msgid "Enter a name for the new playlist"
 msgstr "Skriv inn et navn på den nye spillelisten"
 
 #. TRANSLATORS: "_" marks the mnemonic key
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:524
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:588
 #: src/main/java/org/subsound/ui/components/ServerBadge.java:168
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1531
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1575
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1598
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1642
 #, java-printf-format
 msgid "_Cancel"
 msgstr "_Avbryt"
 
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:525
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:589
 #, java-printf-format
 msgid "_Create"
 msgstr "_Opprett"
 
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:684
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:688
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:691
-#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:696
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:748
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:752
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:755
+#: src/main/java/org/subsound/ui/components/PlaylistsListView.java:760
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:393
 #, java-printf-format
 msgid "%d item"
 msgid_plural "%d items"
@@ -495,211 +496,211 @@ msgstr ""
 msgid "Configuration saved!"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:84
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:85
 #, java-printf-format
 msgid "Clear song cache"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:88
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:89
 #, java-printf-format
 msgid "Clear thumbnail cache"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:92
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:93
 #, java-printf-format
 msgid "Clear lyrics cache"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:97
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:98
 #, java-printf-format
 msgid "Local Settings"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:107
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:131
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:108
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:132
 #, java-printf-format
 msgid "Source"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:124
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:125
 #, java-printf-format
 msgid "Audio format"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:135
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:136
 #, java-printf-format
 msgid "Max bitrate"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:161
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:162
 #, java-printf-format
 msgid "Server information"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:163
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:164
 #, java-printf-format
 msgid "Type"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:164
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:165
 #, java-printf-format
 msgid "Version"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:165
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:166
 #, java-printf-format
 msgid "API Version"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:166
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:167
 #, java-printf-format
 msgid "OpenSubsonic support"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:171
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:172
 #, java-printf-format
 msgid "OpenSubsonic extensions"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:176
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:177
 #, java-printf-format
 msgid "Transcode Settings"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:184
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:187
 #, java-printf-format
 msgid "Enable ReplayGain"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:185
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:188
 #, java-printf-format
 msgid "Normalize playback loudness across tracks"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:190
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:193
 #, java-printf-format
 msgid "Track"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:193
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:196
 #, java-printf-format
 msgid "Normalization mode"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:194
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:197
 #, java-printf-format
 msgid "Album mode preserves an album's internal dynamics"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:199
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:202
 #, java-printf-format
 msgid "Pre-amp (dB)"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:204
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:207
 #, java-printf-format
 msgid "Fallback gain (dB)"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:205
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:208
 #, java-printf-format
 msgid "Applied to tracks without ReplayGain data"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:210
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:213
 #, java-printf-format
 msgid "ReplayGain"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:228
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:231
 #, java-printf-format
 msgid "Full scan"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:230
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:233
 #, java-printf-format
 msgid "Start server scan for new songs and folders"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:238
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:241
 #, java-printf-format
 msgid "Quick scan"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:240
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:243
 #, java-printf-format
 msgid "Start server quick scan for new songs and folders"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:247
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:250
 #, java-printf-format
 msgid "Last Scanned at"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:248
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:251
 #, java-printf-format
 msgid "Status"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:249
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:252
 #, java-printf-format
 msgid "Server songs"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:259
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:262
 #, java-printf-format
 msgid "Local songs"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:263
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:266
 #, java-printf-format
 msgid "Sync library"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:265
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:268
 #, java-printf-format
 msgid "Syncs metadata for offline use"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:280
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:283
 #, java-printf-format
 msgid "Local Library"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:359
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:360
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:362
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:363
 #, java-printf-format
 msgid "Unknown"
 msgstr "Ukjent"
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:362
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:365
 #, java-printf-format
 msgid "No"
 msgstr "Nei"
 
-#: src/main/java/org/subsound/ui/components/SettingsPage.java:362
+#: src/main/java/org/subsound/ui/components/SettingsPage.java:365
 #, java-printf-format
 msgid "Yes"
 msgstr "Ja"
 
 #: src/main/java/org/subsound/ui/components/SongContextMenu.java:68
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:417
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1334
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1657
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1401
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1724
 #, java-printf-format
 msgid "Play"
 msgstr "Spill av"
 
 #: src/main/java/org/subsound/ui/components/SongContextMenu.java:74
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:438
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1680
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1747
 #, java-printf-format
 msgid "Play Next"
 msgstr "Spill neste"
 
 #: src/main/java/org/subsound/ui/components/SongContextMenu.java:80
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:444
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1686
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1753
 #, java-printf-format
 msgid "Add to Queue"
 msgstr "Legg til i kø"
@@ -712,22 +713,22 @@ msgstr "Legg til i favoritter"
 #: src/main/java/org/subsound/ui/components/SongContextMenu.java:101
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:459
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:673
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1338
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1692
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1405
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1759
 #, java-printf-format
 msgid "Add to Playlist…"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/components/SongContextMenu.java:112
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:464
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1340
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1695
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1407
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1762
 #, java-printf-format
 msgid "Download"
 msgstr "Last ned"
 
 #: src/main/java/org/subsound/ui/components/SongDownloadStatusIcon.java:44
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1423
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1490
 #, java-printf-format
 msgid "Available offline"
 msgstr ""
@@ -764,13 +765,13 @@ msgid "Add to Starred"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:450
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1344
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1411
 #, java-printf-format
 msgid "Unstar"
 msgstr ""
 
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:490
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1736
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1803
 #, java-printf-format
 msgid "← Back"
 msgstr ""
@@ -783,7 +784,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/main/java/org/subsound/ui/views/AlbumInfoPage.java:658
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1387
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1454
 #, java-printf-format
 msgid "Download all"
 msgstr "Last ned alle"
@@ -857,146 +858,146 @@ msgstr[1] ""
 msgid "Scanned %s ago"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:263
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:275
 #, java-printf-format
 msgid "Filter by title, artist, or album"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:389
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:911
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:438
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:978
 #, java-printf-format
 msgid "Title"
 msgstr "Tittel"
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:498
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:547
 #, java-printf-format
 msgid "Duration"
 msgstr "Lengde"
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:680
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:729
 #, java-printf-format
 msgid "Refresh playlist"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1320
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1387
 #, java-printf-format
 msgid "Clear selection"
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1336
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1403
 #, fuzzy, java-printf-format
 msgid "Add to queue"
 msgstr "Legg til i kø"
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1342
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1409
 #, fuzzy, java-printf-format
 msgid "Star"
 msgstr "Favoritter"
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1346
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1374
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1708
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1413
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1441
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1775
 #, java-printf-format
 msgid "Remove from Playlist"
 msgstr "Fjern fra spilleliste"
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1369
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1436
 #, fuzzy, java-printf-format
 msgid "%d selected"
 msgid_plural "%d selected"
 msgstr[0] "%d sek"
 msgstr[1] "%d sek"
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1373
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1717
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1440
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1784
 #, java-printf-format
 msgid "Remove from Downloads"
 msgstr "Fjern fra nedlastinger"
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1386
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1453
 #, java-printf-format
 msgid "Rename…"
 msgstr "Gi nytt navn…"
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1388
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1455
 #, java-printf-format
 msgid "Delete Playlist…"
 msgstr "Slett spilleliste…"
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1527
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1594
 #, java-printf-format
 msgid "Rename Playlist"
 msgstr "Gi nytt navn"
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1528
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1595
 #, java-printf-format
 msgid "Enter a new name for \"%s\""
 msgstr "Skriv inn nytt navn for '%s'"
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1532
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1599
 #, java-printf-format
 msgid "_Rename"
 msgstr "_Gi nytt navn"
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1571
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1638
 #, java-printf-format
 msgid "Delete Playlist"
 msgstr "Slett spilleliste"
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1572
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1639
 #, java-printf-format
 msgid "Delete \"%s\"? This cannot be undone."
 msgstr ""
 
-#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1576
+#: src/main/java/org/subsound/ui/views/PlaylistListViewV2.java:1643
 #, java-printf-format
 msgid "_Delete"
 msgstr "_Slett"
 
-#: src/main/java/org/subsound/utils/Utils.java:182
-#: src/main/java/org/subsound/utils/Utils.java:206
+#: src/main/java/org/subsound/utils/Utils.java:190
+#: src/main/java/org/subsound/utils/Utils.java:214
 #, java-printf-format
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] "%d dag"
 msgstr[1] "%d dager"
 
-#: src/main/java/org/subsound/utils/Utils.java:185
+#: src/main/java/org/subsound/utils/Utils.java:193
 #, java-printf-format
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] "%d time"
 msgstr[1] "%d timer"
 
-#: src/main/java/org/subsound/utils/Utils.java:188
+#: src/main/java/org/subsound/utils/Utils.java:196
 #, java-printf-format
 msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] "%d minutt"
 msgstr[1] "%d minutter"
 
-#: src/main/java/org/subsound/utils/Utils.java:191
+#: src/main/java/org/subsound/utils/Utils.java:199
 #, java-printf-format
 msgid "%d second"
 msgid_plural "%d seconds"
 msgstr[0] "%d sekund"
 msgstr[1] "%d sekunder"
 
-#: src/main/java/org/subsound/utils/Utils.java:211
+#: src/main/java/org/subsound/utils/Utils.java:219
 #, java-printf-format
 msgid "%d hr"
 msgid_plural "%d hr"
 msgstr[0] "%dt"
 msgstr[1] "%dt"
 
-#: src/main/java/org/subsound/utils/Utils.java:214
+#: src/main/java/org/subsound/utils/Utils.java:222
 #, java-printf-format
 msgid "%d min"
 msgid_plural "%d min"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/main/java/org/subsound/utils/Utils.java:217
+#: src/main/java/org/subsound/utils/Utils.java:225
 #, java-printf-format
 msgid "%d sec"
 msgid_plural "%d sec"

--- a/src/main/java/org/subsound/ui/components/Classes.java
+++ b/src/main/java/org/subsound/ui/components/Classes.java
@@ -56,7 +56,11 @@ public enum Classes {
     lyricsLineActive("lyrics-line-active"),
     lyricsLinePage("lyrics-line-page"),
     commandPalette("command-palette"),
-    commandPaletteBackdrop("command-palette-backdrop");
+    commandPaletteBackdrop("command-palette-backdrop"),
+    dropTargetActive("drop-target-active"),
+    dropTargetSlot("drop-target-slot"),
+    playlistDropRow("playlist-drop-row"),
+    dragSongBadge("drag-song-badge");
 
     private final String className;
     Classes(String className) {

--- a/src/main/java/org/subsound/ui/components/PlaylistsListView.java
+++ b/src/main/java/org/subsound/ui/components/PlaylistsListView.java
@@ -8,11 +8,14 @@ import org.gnome.adw.NavigationSplitView;
 import org.gnome.adw.ResponseAppearance;
 import org.gnome.adw.StatusPage;
 import org.gnome.adw.TimedAnimation;
+import org.gnome.gdk.DragAction;
 import org.gnome.gdk.Gdk;
 import org.gnome.gio.ListStore;
+import org.gnome.gobject.Value;
 import org.gnome.gtk.Align;
 import org.gnome.gtk.Box;
 import org.gnome.gtk.Button;
+import org.gnome.gtk.DropTarget;
 import org.gnome.gtk.Entry;
 import org.gnome.gtk.EventControllerFocus;
 import org.gnome.gtk.EventControllerMotion;
@@ -38,13 +41,17 @@ import org.subsound.app.state.PlaylistsStore.GPlaylist;
 import org.subsound.integration.ServerClient.PlaylistKind;
 import org.subsound.integration.ServerClient.PlaylistSimple;
 import org.subsound.integration.ServerClient.SongInfo;
+import org.subsound.ui.models.GSongInfo;
 import org.subsound.ui.models.GSongStore;
 import org.subsound.ui.views.PlaylistListViewV2;
 import org.subsound.utils.Utils;
+import org.javagi.gobject.types.Types;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -60,6 +67,7 @@ import static org.subsound.utils.Utils.doAsync;
 
 public class PlaylistsListView extends Box {
     private static final Logger log = LoggerFactory.getLogger(PlaylistsListView.class);
+    private static final Set<DragAction> DRAG_ACTION_COPY = Set.of(DragAction.COPY);
 
     private final AppManager appManager;
     private final ListStore<GPlaylist> listModel;
@@ -158,6 +166,25 @@ public class PlaylistsListView extends Box {
                 openPlaylist(row.getPlaylist());
             });
             row.addController(rowClick);
+            // Drop target: dropping songs dragged from a playlist's song list adds them to the
+            // playlist this (recycled) row shows. Only NORMAL playlists accept — the synthetic
+            // Starred/Downloaded rows reject the drop (no highlight, no-op), mirroring the
+            // "Add to Playlist" menu which also only lists NORMAL playlists.
+            var dropTarget = new DropTarget(Types.STRING, DragAction.COPY);
+            dropTarget.onAccept(_ -> isDropTarget(row.getPlaylist()));
+            dropTarget.onEnter((x, y) -> {
+                if (!isDropTarget(row.getPlaylist())) {
+                    return Set.of();
+                }
+                row.setDropHighlight(true);
+                return DRAG_ACTION_COPY;
+            });
+            dropTarget.onLeave(() -> row.setDropHighlight(false));
+            dropTarget.onDrop((value, x, y) -> {
+                row.setDropHighlight(false);
+                return handleSongDrop(row.getPlaylist(), value);
+            });
+            row.addController(dropTarget);
             listitem.setChild(row);
         });
 
@@ -313,6 +340,43 @@ public class PlaylistsListView extends Box {
         this.setHexpand(true);
         this.setVexpand(true);
         this.append(view);
+    }
+
+    // A drop is only accepted on real (NORMAL) playlists. The synthetic Starred/Downloaded
+    // rows are not user-editable song containers, so they never accept a song drop.
+    private static boolean isDropTarget(GPlaylist gPlaylist) {
+        return gPlaylist != null && gPlaylist.getPlaylist().kind() == PlaylistKind.NORMAL;
+    }
+
+    // Handle songs dropped onto a playlist row: parse the drag payload (a G_TYPE_STRING of
+    // song ids produced by PlaylistListViewV2), resolve them to GSongInfo via the shared song
+    // store, and dispatch AddManyToPlaylist (which refreshes the playlist and toasts). Returns
+    // whether the drop was consumed.
+    private boolean handleSongDrop(GPlaylist gPlaylist, Value value) {
+        if (!isDropTarget(gPlaylist)) {
+            return false;
+        }
+        String data = value.getString();
+        if (data == null || !data.startsWith(PlaylistListViewV2.SONGS_DRAG_PREFIX)) {
+            return false;
+        }
+        var idsPart = data.substring(PlaylistListViewV2.SONGS_DRAG_PREFIX.length());
+        if (idsPart.isBlank()) {
+            return false;
+        }
+        var songs = new ArrayList<GSongInfo>();
+        for (var id : idsPart.split(",")) {
+            if (!id.isBlank()) {
+                // Ids come from rows the source view just displayed, so they are already in the
+                // store; getExisting avoids a blocking server load if one is somehow missing.
+                this.songStore.getExisting(id).ifPresent(songs::add);
+            }
+        }
+        if (songs.isEmpty()) {
+            return false;
+        }
+        appManager.handleAction(new PlayerAction.AddManyToPlaylist(songs, gPlaylist.getId(), gPlaylist.getName()));
+        return true;
     }
 
     // Open the given playlist (single-click path from a row's gesture). Resolves its current
@@ -560,12 +624,17 @@ public class PlaylistsListView extends Box {
         private final Label titleLabel;
         private final Label subtitleLabel;
         private final Image subtitleCheckmark;
+        private final Box contentBox;
         private GPlaylist gPlaylist;
         private SignalConnection<NotifyCallback> notifySignal;
 
         public PlaylistRowWidget(AppManager appManager) {
             super(HORIZONTAL, 12);
             this.appManager = appManager;
+
+            // Suppress the theme's default whole-row :drop(active) outline; we draw our own
+            // marker on the content box instead (see setDropHighlight / .drop-target-active).
+            this.addCssClass(Classes.playlistDropRow.className());
 
             this.setMarginTop(8);
             this.setMarginBottom(8);
@@ -603,11 +672,14 @@ public class PlaylistsListView extends Box {
             this.prefixBox.append(prefixIconDownload);
             this.prefixBox.append(prefixIconStar);
 
-            // Content box for title and subtitle
-            var contentBox = new Box(VERTICAL, 2);
-            contentBox.setHalign(START);
-            contentBox.setValign(CENTER);
-            contentBox.setHexpand(true);
+            // Content box for title and subtitle. This (not the whole row) carries the
+            // drop-target highlight, so the marker outlines only the title/subtitle area and
+            // does not draw behind the album art on the left.
+            this.contentBox = new Box(VERTICAL, 2);
+            this.contentBox.setHalign(FILL);
+            this.contentBox.setValign(CENTER);
+            this.contentBox.setHexpand(true);
+            this.contentBox.addCssClass(Classes.dropTargetSlot.className());
 
             this.titleLabel = Label.builder()
                     .setLabel("")
@@ -636,11 +708,21 @@ public class PlaylistsListView extends Box {
             subtitleRow.append(subtitleCheckmark);
             subtitleRow.append(subtitleLabel);
 
-            contentBox.append(titleLabel);
-            contentBox.append(subtitleRow);
+            this.contentBox.append(titleLabel);
+            this.contentBox.append(subtitleRow);
 
             this.append(prefixBox);
-            this.append(contentBox);
+            this.append(this.contentBox);
+        }
+
+        // Toggle the drop-target highlight, drawn on the content box so it outlines only the
+        // title/subtitle area (never behind the album art).
+        public void setDropHighlight(boolean on) {
+            if (on) {
+                this.contentBox.addCssClass(Classes.dropTargetActive.className());
+            } else {
+                this.contentBox.removeCssClass(Classes.dropTargetActive.className());
+            }
         }
 
         public GPlaylist getPlaylist() {

--- a/src/main/java/org/subsound/ui/views/PlaylistListViewV2.java
+++ b/src/main/java/org/subsound/ui/views/PlaylistListViewV2.java
@@ -2,7 +2,10 @@ package org.subsound.ui.views;
 
 import org.gnome.adw.AlertDialog;
 import org.gnome.adw.Clamp;
+import org.gnome.gdk.ContentProvider;
+import org.gnome.gdk.DragAction;
 import org.gnome.gdk.ModifierType;
+import org.gnome.gobject.Value;
 import org.gnome.gio.ListModel;
 import org.gnome.gio.ListStore;
 import org.gnome.glib.Type;
@@ -14,6 +17,8 @@ import org.gnome.gtk.ColumnView;
 import org.gnome.gtk.ColumnViewColumn;
 import org.gnome.gtk.ColumnViewSorter;
 import org.gnome.gtk.CustomFilter;
+import org.gnome.gtk.DragIcon;
+import org.gnome.gtk.DragSource;
 import org.gnome.gtk.Entry;
 import org.gnome.gtk.EventControllerKey;
 import org.gnome.gtk.FilterChange;
@@ -95,6 +100,13 @@ import static org.subsound.ui.views.AlbumInfoPage.infoLabel;
 
 public class PlaylistListViewV2 extends Box implements AppManager.StateListener {
     private static final Logger log = LoggerFactory.getLogger(PlaylistListViewV2.class);
+
+    /**
+     * Prefix for the {@code G_TYPE_STRING} drag payload produced when dragging song rows out
+     * of this view. The remainder is a comma-separated list of song ids. Drop targets (e.g.
+     * the playlists overview) match on this prefix to reject foreign/plain-text drags.
+     */
+    public static final String SONGS_DRAG_PREFIX = "subsound-songs:";
 
     private final AppManager appManager;
     private final ColumnView columnView;
@@ -347,6 +359,52 @@ public class PlaylistListViewV2 extends Box implements AppManager.StateListener 
         titleFactory.onSetup(obj -> {
             var listItem = (ListItem) obj;
             var cell = new TitleArtistCell(appManager, this.onNavigate);
+            // Drag source: the title cell is the drag handle for its song row. Dragging a row
+            // that is part of the current multi-selection drags the whole selection; otherwise
+            // just that one song. The payload is a G_TYPE_STRING of song ids (see songsForDrag).
+            var dragSource = new DragSource();
+            dragSource.setActions(DragAction.COPY);
+            dragSource.onPrepare((x, y) -> {
+                var entry = cell.boundEntry;
+                if (entry == null) {
+                    return null;
+                }
+                var songs = songsForDrag(entry);
+                if (songs.isEmpty()) {
+                    return null;
+                }
+                var ids = songs.stream().map(GSongInfo::getId).toList();
+                var value = new Value();
+                value.init(Types.STRING);
+                value.setString(SONGS_DRAG_PREFIX + String.join(",", ids));
+                return ContentProvider.forValue(value);
+            });
+            // Replace the default drag cursor with a small "N items" badge. The badge sits in a
+            // transparent box offset from the hotspot (pinned to 0,0) so the cursor stays clear
+            // of the pill's text instead of covering it.
+            dragSource.onDragBegin(drag -> {
+                var entry = cell.boundEntry;
+                if (entry == null) {
+                    return;
+                }
+                int count = songsForDrag(entry).size();
+                if (count == 0) {
+                    return;
+                }
+                var badge = Label.builder()
+                        .setLabel(trn("%d item", "%d items", count).formatted(count))
+                        .setCssClasses(new String[]{Classes.dragSongBadge.className()})
+                        .build();
+                var iconBox = Box.builder()
+                        .setOrientation(HORIZONTAL)
+                        .setMarginTop(10)
+                        .setMarginStart(14)
+                        .build();
+                iconBox.append(badge);
+                drag.setHotspot(0, 0);
+                DragIcon.getForDrag(drag).setChild(iconBox);
+            });
+            cell.addController(dragSource);
             listItem.setChild(cell);
         });
         titleFactory.onBind(obj -> {
@@ -735,6 +793,24 @@ public class PlaylistListViewV2 extends Box implements AppManager.StateListener 
             out.add(e.gSong());
         }
         return out;
+    }
+
+    /**
+     * The songs to carry when {@code entry}'s row is dragged: the whole multi-selection when
+     * {@code entry} is part of a 2+ selection, otherwise just {@code entry} itself. Model items
+     * are stable instances, so identity ({@code ==}) membership is correct. Main thread only.
+     */
+    private List<GSongInfo> songsForDrag(GPlaylistEntry entry) {
+        var selected = selectedEntries();
+        boolean entryInSelection = selected.stream().anyMatch(e -> e == entry);
+        if (entryInSelection && selected.size() >= 2) {
+            var out = new ArrayList<GSongInfo>(selected.size());
+            for (var e : selected) {
+                out.add(e.gSong());
+            }
+            return out;
+        }
+        return List.of(entry.gSong());
     }
 
     /**

--- a/src/main/resources/css/main.css
+++ b/src/main/resources/css/main.css
@@ -134,6 +134,41 @@ scale slider {
   margin: 6px;
 }
 
+/* A playlist row in the overview that is a valid drop target while a song drag
+ * hovers over it. Uses the accent colour so it reads as "release here to add". */
+/* Permanent padding on the row's content box so the drop-target outline (added on top via
+ * .drop-target-active) has breathing room around the title/subtitle and toggling the marker
+ * causes no layout shift. Transparent otherwise — invisible in the normal state. */
+.drop-target-slot {
+  padding: 3px 8px;
+  border-radius: 6px;
+}
+
+.drop-target-active {
+  background-color: alpha(@accent_bg_color, 0.25);
+  box-shadow: inset 0 0 0 2px @accent_bg_color;
+}
+
+/* Suppress the theme's built-in whole-row drop highlight (drawn on the widget that owns the
+ * DropTarget when it is the active drop target). We render our own marker on the content box
+ * via .drop-target-active, so the row itself must stay unstyled. */
+.playlist-drop-row:drop(active) {
+  box-shadow: none;
+  outline: none;
+  background-color: transparent;
+}
+
+/* The badge shown under the cursor while dragging songs onto a playlist: a small
+ * rounded "N items" pill on a solid themed surface. */
+.drag-song-badge {
+  padding: 6px 10px;
+  border-radius: 8px;
+  background-color: @popover_bg_color;
+  color: @popover_fg_color;
+  font-weight: 600;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+}
+
 .command-palette-backdrop {
   background-color: rgba(0, 0, 0, 0.5);
 }


### PR DESCRIPTION
Drag songs from a playlist's song list (PlaylistListViewV2) onto a NORMAL playlist row in the overview sidebar (PlaylistsListView) to add them.

- Drag source on each song row's title cell; payload is a G_TYPE_STRING of song ids ("subsound-songs:<id,...>"). Dragging a row within a 2+ selection drags the whole selection, otherwise just that song.
- Drop target on each playlist row, gated to PlaylistKind.NORMAL (Starred/ Downloaded reject), with a .drop-target-active hover highlight. Resolves ids via GSongStore and dispatches the existing AddManyToPlaylist action.
